### PR TITLE
Remove allowBackup from manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /build
 /captures
 /.gradle
+/.idea

--- a/android-client/src/main/AndroidManifest.xml
+++ b/android-client/src/main/AndroidManifest.xml
@@ -5,7 +5,6 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
-        android:allowBackup="true"
         android:label="@string/app_name"
         android:supportsRtl="true">
         <activity android:name=".LaunchDarklyActivity" android:theme="@android:style/Theme.NoDisplay"/>


### PR DESCRIPTION
In general libraries should not specify this, as the setting can cause manifest conflicts.
