### PR TITLE
2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 
 All notable changes to the LaunchDarkly Android SDK will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
+## [2.0.0] - 2017-04-10
+### Added
+- More configurable flag update mechanisms including the ability to disable streaming. See README.md for details.
+
+### Changed
+- API BREAKING CHANGE: Guava ListenableFuture is no longer returned from LDClient. Instead we're returning java.util.concurrent.Future.
+- Added configurable background polling.
+- Improved Json variation handling.
+- Improved stream connection lifecycle management.
+- Removed SLF4J logger in LDUser.
+- Updated suggested Proguard rules for a smaller footprint.
+
+### Fixed
+- [Update to Latest version of OkHttp](https://github.com/launchdarkly/android-client/issues/20)
 
 ## [1.0.1] - 2016-11-17
 ### Added

--- a/README.md
+++ b/README.md
@@ -59,6 +59,35 @@ If you're using ProGuard add these lines to your config:
 -dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 ```
 
+## Feature Flag Updating
+The LaunchDarkly Android SDK defaults to what we have found to be the best combination of low latency updates and minimal battery drain:
+
+1. When the app is foregrounded an Server-Sent Events streaming connection is made to LaunchDarkly. This streaming connection stays open as long as your app is in the foreground and is connected to the internet.
+1. When the app is backgrounded, the stream connection is terminated and the SDK will poll (with caching) for flag updates every 5 minutes.
+1. When the app is foregrounded, we fetch the latest flags and reconnect to the stream. 
+1. In either the foreground or background, we don't try to update unless your device has internet connectivity.
+
+This configuration means that you will get near real-time updates for your feature flag values when the app is in the foreground.
+
+###Other Options
+If you prefer other options, here they are:
+
+1. Streaming can be disabled in favor of polling updates. To disable streaming call `.setStream(false)` on the `LDConfig.Builder` object.
+1. The default polling interval is 5 minutes. To change it call `.setPollingIntervalMillis()` on the `LDConfig.Builder` object.
+1. Background polling can be disabled (the app will only receive updates when the app is in the foreground). To disable background updating call `.setDisableBackgroundUpdating(true)` on the `LDConfig.Builder` object.
+1. The background polling interval can be adjusted (with the same minimum of 60 seconds). To change it call `.setBackgroundPollingIntervalMillis()` on the `LDConfig.Builder` object.
+
+Example config with streaming disabled and custom polling intervals:
+
+```
+ LDConfig config = new LDConfig.Builder()
+                .setStream(false)
+                .setPollingIntervalMillis(600_000) // 10 minutes
+                .setBackgroundPollingIntervalMillis(3_600_000) // 1 hour
+                .build();
+```
+ 
+
 ## Known Issues/Features not yet implemented:
 - Make Android linter happy
 

--- a/README.md
+++ b/README.md
@@ -46,10 +46,11 @@ If you're using ProGuard add these lines to your config:
 ```
 -keep class com.launchdarkly.android.** { *; }
 -keep class org.apache.http.** { *; }
--keep class com.google.common.** { *; }
--keep class org.slf4j.** { *; }
+-dontwarn okio.**
+-dontwarn okhttp3.**
 -dontwarn org.apache.http.**
 -dontwarn org.slf4j.**
+-dontwarn com.google.common.**
 -dontwarn java.nio.file.*
 -dontwarn javax.annotation.**
 -dontwarn sun.misc.Unsafe

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ If you're using ProGuard add these lines to your config:
 ## Feature Flag Updating
 The LaunchDarkly Android SDK defaults to what we have found to be the best combination of low latency updates and minimal battery drain:
 
-1. When the app is foregrounded an Server-Sent Events streaming connection is made to LaunchDarkly. This streaming connection stays open as long as your app is in the foreground and is connected to the internet.
-1. When the app is backgrounded, the stream connection is terminated and the SDK will poll (with caching) for flag updates every 5 minutes.
+1. When the app is foregrounded a [Server-Sent Events](https://en.wikipedia.org/wiki/Server-sent_events) streaming connection is made to LaunchDarkly. This streaming connection stays open as long as your app is in the foreground and is connected to the internet.
+1. When the app is backgrounded, the stream connection is terminated and the SDK will poll (with caching) for flag updates every 15 minutes.
 1. When the app is foregrounded, we fetch the latest flags and reconnect to the stream. 
 1. In either the foreground or background, we don't try to update unless your device has internet connectivity.
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,11 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.1'
+
+        // For displaying method/field counts when building with Gradle:
+        // https://github.com/KeepSafe/dexcount-gradle-plugin
+        classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.6.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/circle.yml
+++ b/circle.yml
@@ -6,16 +6,15 @@ machine:
 dependencies:
   pre:
     - unset ANDROID_NDK_HOME
-    - export BUILDTOOLS_VERSION=25.0.0
     # Android SDK Platform 24
     - if [ ! -d "/usr/local/android-sdk-linux/platforms/android-24" ]; then echo y | android update sdk --no-ui --all --filter "android-24"; fi
     # Android SDK Build-tools
-    - if [ ! -d "/usr/local/android-sdk-linux/build-tools/$BUILDTOOLS_VERSION" ]; then echo y | android update sdk --no-ui --all --filter "build-tools-$BUILDTOOLS_VERSION"; fi
+    - if [ ! -d "/usr/local/android-sdk-linux/build-tools/25.0.0" ]; then echo y | android update sdk --no-ui --all --filter "build-tools-25.0.0"; fi
     # brings in appcompat
     - if [ ! -d "/usr/local/android-sdk-linux/extras/android/m2repository" ]; then echo y | android update sdk --no-ui --all --filter "extra-android-m2repository"; fi
   cache_directories:
     - /usr/local/android-sdk-linux/platforms/android-24
-    - /usr/local/android-sdk-linux/build-tools/$BUILDTOOLS_VERSION
+    - /usr/local/android-sdk-linux/build-tools/25.0.0
     - /usr/local/android-sdk-linux/extras/android/m2repository
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -9,12 +9,12 @@ dependencies:
     # Android SDK Platform 24
     - if [ ! -d "/usr/local/android-sdk-linux/platforms/android-24" ]; then echo y | android update sdk --no-ui --all --filter "android-24"; fi
     # Android SDK Build-tools
-    - if [ ! -d "/usr/local/android-sdk-linux/build-tools/25.0.0" ]; then echo y | android update sdk --no-ui --all --filter "build-tools-25.0.0"; fi
+    - if [ ! -d "/usr/local/android-sdk-linux/build-tools/25.0.2" ]; then echo y | android update sdk --no-ui --all --filter "build-tools-25.0.2"; fi
     # brings in appcompat
     - if [ ! -d "/usr/local/android-sdk-linux/extras/android/m2repository" ]; then echo y | android update sdk --no-ui --all --filter "extra-android-m2repository"; fi
   cache_directories:
     - /usr/local/android-sdk-linux/platforms/android-24
-    - /usr/local/android-sdk-linux/build-tools/25.0.0
+    - /usr/local/android-sdk-linux/build-tools/25.0.2
     - /usr/local/android-sdk-linux/extras/android/m2repository
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -25,6 +25,5 @@ test:
     - ./gradlew :launchdarkly-android-client:assembleDebug --console=plain -PdisablePreDex
     - ./gradlew :launchdarkly-android-client:test --console=plain -PdisablePreDex
     - ./gradlew :launchdarkly-android-client:connectedAndroidTest --console=plain -PdisablePreDex
-    - ls -latrh
     - cp -r launchdarkly-android-client/build/reports/* $CIRCLE_TEST_REPORTS
     - ./gradlew packageRelease --console=plain -PdisablePreDex

--- a/circle.yml
+++ b/circle.yml
@@ -1,24 +1,30 @@
+# Disable emulator audio
+machine:
+  environment:
+    QEMU_AUDIO_DRV: none
+
 dependencies:
   pre:
     - unset ANDROID_NDK_HOME
+    - export BUILDTOOLS_VERSION=25.0.0
     # Android SDK Platform 24
     - if [ ! -d "/usr/local/android-sdk-linux/platforms/android-24" ]; then echo y | android update sdk --no-ui --all --filter "android-24"; fi
-    # Android SDK Build-tools, revision 24.0.2
-    - if [ ! -d "/usr/local/android-sdk-linux/build-tools/24.0.2" ]; then echo y | android update sdk --no-ui --all --filter "build-tools-24.0.2"; fi
+    # Android SDK Build-tools
+    - if [ ! -d "/usr/local/android-sdk-linux/build-tools/$BUILDTOOLS_VERSION" ]; then echo y | android update sdk --no-ui --all --filter "build-tools-$BUILDTOOLS_VERSION"; fi
     # brings in appcompat
     - if [ ! -d "/usr/local/android-sdk-linux/extras/android/m2repository" ]; then echo y | android update sdk --no-ui --all --filter "extra-android-m2repository"; fi
   cache_directories:
     - /usr/local/android-sdk-linux/platforms/android-24
-    - /usr/local/android-sdk-linux/build-tools/24.0.2
+    - /usr/local/android-sdk-linux/build-tools/$BUILDTOOLS_VERSION
     - /usr/local/android-sdk-linux/extras/android/m2repository
 test:
   override:
-    - emulator -avd circleci-android23 -no-audio -no-window:
+    - emulator -avd circleci-android24 -no-audio -no-window:
         background: true
         parallel: true
+    - circle-android wait-for-boot
     - ./gradlew :launchdarkly-android-client:assembleDebug --console=plain -PdisablePreDex
     - ./gradlew :launchdarkly-android-client:test --console=plain -PdisablePreDex
-    - circle-android wait-for-boot
     - ./gradlew :launchdarkly-android-client:connectedAndroidTest --console=plain -PdisablePreDex
     - ls -latrh
     - cp -r launchdarkly-android-client/build/reports/* $CIRCLE_TEST_REPORTS

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,6 @@
 dependencies:
   pre:
+    - unset ANDROID_NDK_HOME
     # Android SDK Platform 24
     - if [ ! -d "/usr/local/android-sdk-linux/platforms/android-24" ]; then echo y | android update sdk --no-ui --all --filter "android-24"; fi
     # Android SDK Build-tools, revision 24.0.2

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -1,4 +1,6 @@
 apply plugin: 'com.android.application'
+// make sure this line comes *after* you apply the Android plugin
+apply plugin: 'com.getkeepsafe.dexcount'
 
 repositories {
     mavenLocal()

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -9,7 +9,7 @@ repositories {
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    buildToolsVersion '25.0.0'
     defaultConfig {
         applicationId "com.launchdarkly.example"
         minSdkVersion 15

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -11,7 +11,7 @@ repositories {
 
 android {
     compileSdkVersion 24
-    buildToolsVersion '25.0.0'
+    buildToolsVersion '25.0.2'
     defaultConfig {
         applicationId "com.launchdarkly.example"
         minSdkVersion 15

--- a/example/proguard-rules.pro
+++ b/example/proguard-rules.pro
@@ -10,10 +10,11 @@
 # Add any project specific keep options here:
 -keep class com.launchdarkly.android.** { *; }
 -keep class org.apache.http.** { *; }
--keep class com.google.common.** { *; }
--keep class org.slf4j.** { *; }
+-dontwarn okio.**
+-dontwarn okhttp3.**
 -dontwarn org.apache.http.**
 -dontwarn org.slf4j.**
+-dontwarn com.google.common.**
 -dontwarn java.nio.file.*
 -dontwarn javax.annotation.**
 -dontwarn sun.misc.Unsafe

--- a/example/src/main/java/com/launchdarkly/example/MainActivity.java
+++ b/example/src/main/java/com/launchdarkly/example/MainActivity.java
@@ -12,7 +12,6 @@ import android.widget.Spinner;
 import android.widget.Switch;
 import android.widget.TextView;
 
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.gson.JsonNull;
 import com.launchdarkly.android.FeatureFlagChangeListener;
 import com.launchdarkly.android.LDClient;
@@ -20,6 +19,7 @@ import com.launchdarkly.android.LDConfig;
 import com.launchdarkly.android.LDUser;
 
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -47,7 +47,7 @@ public class MainActivity extends AppCompatActivity {
                 .email("fake@example.com")
                 .build();
 
-        ListenableFuture<LDClient> initFuture = LDClient.init(this.getApplication(), ldConfig, user);
+        Future<LDClient> initFuture = LDClient.init(this.getApplication(), ldConfig, user);
         try {
             ldClient = initFuture.get(10, TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Aug 16 13:54:02 PDT 2016
+#Mon Apr 03 14:14:24 PDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/launchdarkly-android-client/build.gradle
+++ b/launchdarkly-android-client/build.gradle
@@ -14,7 +14,7 @@ allprojects {
 
 android {
     compileSdkVersion 24
-    buildToolsVersion '25.0.0'
+    buildToolsVersion '25.0.2'
 
     defaultConfig {
         minSdkVersion 15

--- a/launchdarkly-android-client/build.gradle
+++ b/launchdarkly-android-client/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     compile 'com.google.guava:guava:20.0'
     compile 'com.noveogroup.android:android-logger:1.3.5'
     compile 'com.google.code.gson:gson:2.7'
-    compile 'com.launchdarkly:okhttp-eventsource:1.1.1'
+    compile 'com.launchdarkly:okhttp-eventsource:1.3.0'
     compile 'com.squareup.okhttp3:okhttp:3.6.0'
 
     androidTestCompile 'com.android.support:appcompat-v7:24.2.1'
@@ -57,7 +57,7 @@ dependencies {
 
     javadocDeps 'com.google.code.gson:gson:2.7'
     javadocDeps 'com.squareup.okhttp3:okhttp:3.6.0'
-    javadocDeps 'com.launchdarkly:okhttp-eventsource:1.1.1'
+    javadocDeps 'com.launchdarkly:okhttp-eventsource:1.3.0'
 }
 
 repositories {

--- a/launchdarkly-android-client/build.gradle
+++ b/launchdarkly-android-client/build.gradle
@@ -2,10 +2,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'org.ajoberstar.github-pages'
+// make sure this line comes *after* you apply the Android plugin
+apply plugin: 'com.getkeepsafe.dexcount'
 
 allprojects {
     group = 'com.launchdarkly'
-    version = '1.0.1'
+    version = '2.0.0-SNAPSHOT'
     sourceCompatibility = 1.7
     targetCompatibility = 1.7
 }
@@ -38,14 +40,14 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.google.guava:guava:19.0'
+    compile 'com.google.guava:guava:20.0'
     compile 'com.noveogroup.android:android-logger:1.3.5'
-    compile 'com.google.code.gson:gson:2.6.2'
-    compile 'com.launchdarkly:okhttp-eventsource:0.2.2'
-    compile 'com.squareup.okhttp3:okhttp:3.4.1'
+    compile 'com.google.code.gson:gson:2.7'
+    compile 'com.launchdarkly:okhttp-eventsource:1.1.1'
+    compile 'com.squareup.okhttp3:okhttp:3.6.0'
 
-    androidTestCompile 'com.android.support:appcompat-v7:24.1.1'
-    androidTestCompile 'com.android.support:support-annotations:24.1.1'
+    androidTestCompile 'com.android.support:appcompat-v7:24.2.1'
+    androidTestCompile 'com.android.support:support-annotations:24.2.1'
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
     androidTestCompile 'org.hamcrest:hamcrest-library:1.3'
@@ -53,10 +55,9 @@ dependencies {
     androidTestCompile 'com.google.dexmaker:dexmaker:1.1'
     androidTestCompile 'junit:junit:4.12'
 
-    javadocDeps 'com.google.guava:guava:19.0'
     javadocDeps 'com.google.code.gson:gson:2.7'
-    javadocDeps 'com.squareup.okhttp3:okhttp:3.4.1'
-    javadocDeps 'com.launchdarkly:okhttp-eventsource:1.0.0'
+    javadocDeps 'com.squareup.okhttp3:okhttp:3.6.0'
+    javadocDeps 'com.launchdarkly:okhttp-eventsource:1.1.1'
 }
 
 repositories {
@@ -75,6 +76,7 @@ buildscript {
     dependencies {
         classpath 'org.ajoberstar:gradle-git:1.5.0-rc.1'
         classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'
+        classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.6.3'
     }
 }
 

--- a/launchdarkly-android-client/build.gradle
+++ b/launchdarkly-android-client/build.gradle
@@ -12,7 +12,7 @@ allprojects {
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         minSdkVersion 15

--- a/launchdarkly-android-client/src/androidTest/java/com/launchdarkly/android/LDConfigTest.java
+++ b/launchdarkly-android-client/src/androidTest/java/com/launchdarkly/android/LDConfigTest.java
@@ -41,7 +41,7 @@ public class LDConfigTest {
         assertFalse(config.isStream());
         assertFalse(config.isOffline());
         assertEquals(LDConfig.DEFAULT_POLLING_INTERVAL_MILLIS, config.getPollingIntervalMillis());
-        assertEquals(LDConfig.DEFAULT_POLLING_INTERVAL_MILLIS, PollingUpdater.backgroundPollingIntervalMillis);
+        assertEquals(LDConfig.DEFAULT_BACKGROUND_POLLING_INTERVAL_MILLIS, PollingUpdater.backgroundPollingIntervalMillis);
         assertEquals(LDConfig.DEFAULT_POLLING_INTERVAL_MILLIS, config.getEventsFlushIntervalMillis());
     }
 
@@ -50,13 +50,13 @@ public class LDConfigTest {
         LDConfig config = new LDConfig.Builder()
                 .setStream(false)
                 .setPollingIntervalMillis(LDConfig.DEFAULT_POLLING_INTERVAL_MILLIS + 1)
-                .setBackgroundPollingIntervalMillis(LDConfig.DEFAULT_BACKGROUND_POLLING_INTERVAL_MILLIS + 1)
+                .setBackgroundPollingIntervalMillis(LDConfig.DEFAULT_BACKGROUND_POLLING_INTERVAL_MILLIS + 2)
                 .build();
 
         assertFalse(config.isStream());
         assertFalse(config.isOffline());
         assertEquals(LDConfig.DEFAULT_POLLING_INTERVAL_MILLIS + 1, config.getPollingIntervalMillis());
-        assertEquals(LDConfig.DEFAULT_POLLING_INTERVAL_MILLIS + 1, PollingUpdater.backgroundPollingIntervalMillis);
+        assertEquals(LDConfig.DEFAULT_BACKGROUND_POLLING_INTERVAL_MILLIS + 2, PollingUpdater.backgroundPollingIntervalMillis);
         assertEquals(LDConfig.DEFAULT_POLLING_INTERVAL_MILLIS + 1, config.getEventsFlushIntervalMillis());
     }
 

--- a/launchdarkly-android-client/src/androidTest/java/com/launchdarkly/android/LDConfigTest.java
+++ b/launchdarkly-android-client/src/androidTest/java/com/launchdarkly/android/LDConfigTest.java
@@ -1,0 +1,106 @@
+package com.launchdarkly.android;
+
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+@RunWith(AndroidJUnit4.class)
+public class LDConfigTest {
+
+    @Test
+    public void TestBuilderDefaults(){
+        LDConfig config = new LDConfig.Builder().build();
+        assertTrue(config.isStream());
+        assertFalse(config.isOffline());
+
+        assertEquals(LDConfig.DEFAULT_BASE_URI, config.getBaseUri());
+        assertEquals(LDConfig.DEFAULT_EVENTS_URI, config.getEventsUri());
+        assertEquals(LDConfig.DEFAULT_STREAM_URI, config.getStreamUri());
+
+        assertEquals(LDConfig.DEFAULT_CONNECTION_TIMEOUT_MILLIS, config.getConnectionTimeoutMillis());
+        assertEquals(LDConfig.DEFAULT_EVENTS_CAPACITY, config.getEventsCapacity());
+        assertEquals(LDConfig.DEFAULT_FLUSH_INTERVAL_MILLIS, config.getEventsFlushIntervalMillis());
+        assertEquals(LDConfig.DEFAULT_POLLING_INTERVAL_MILLIS, config.getPollingIntervalMillis());
+
+        assertEquals(LDConfig.DEFAULT_BACKGROUND_POLLING_INTERVAL_MILLIS, config.getBackgroundPollingIntervalMillis());
+        assertEquals(false, config.isDisableBackgroundPolling());
+
+        assertEquals(null, config.getMobileKey());
+    }
+
+
+    @Test
+    public void TestBuilderStreamDisabled() {
+        LDConfig config = new LDConfig.Builder()
+                .setStream(false)
+                .build();
+
+        assertFalse(config.isStream());
+        assertFalse(config.isOffline());
+        assertEquals(LDConfig.DEFAULT_POLLING_INTERVAL_MILLIS, config.getPollingIntervalMillis());
+        assertEquals(LDConfig.DEFAULT_POLLING_INTERVAL_MILLIS, PollingUpdater.backgroundPollingIntervalMillis);
+        assertEquals(LDConfig.DEFAULT_POLLING_INTERVAL_MILLIS, config.getEventsFlushIntervalMillis());
+    }
+
+    @Test
+    public void TestBuilderStreamDisabledCustomIntervals() {
+        LDConfig config = new LDConfig.Builder()
+                .setStream(false)
+                .setPollingIntervalMillis(LDConfig.DEFAULT_POLLING_INTERVAL_MILLIS + 1)
+                .setBackgroundPollingIntervalMillis(LDConfig.DEFAULT_BACKGROUND_POLLING_INTERVAL_MILLIS + 1)
+                .build();
+
+        assertFalse(config.isStream());
+        assertFalse(config.isOffline());
+        assertEquals(LDConfig.DEFAULT_POLLING_INTERVAL_MILLIS + 1, config.getPollingIntervalMillis());
+        assertEquals(LDConfig.DEFAULT_POLLING_INTERVAL_MILLIS + 1, PollingUpdater.backgroundPollingIntervalMillis);
+        assertEquals(LDConfig.DEFAULT_POLLING_INTERVAL_MILLIS + 1, config.getEventsFlushIntervalMillis());
+    }
+
+    @Test
+    public void TestBuilderStreamDisabledBackgroundUpdatingDisabled() {
+        LDConfig config = new LDConfig.Builder()
+                .setStream(false)
+                .setDisableBackgroundUpdating(true)
+                .build();
+
+        assertFalse(config.isStream());
+        assertFalse(config.isOffline());
+        assertTrue(config.isDisableBackgroundPolling());
+        assertEquals(LDConfig.DEFAULT_POLLING_INTERVAL_MILLIS, config.getPollingIntervalMillis());
+        assertEquals(LDConfig.DEFAULT_POLLING_INTERVAL_MILLIS, config.getEventsFlushIntervalMillis());
+    }
+
+    @Test
+    public void TestBuilderStreamDisabledPollingIntervalBelowMinimum() {
+        LDConfig config = new LDConfig.Builder()
+                .setStream(false)
+                .setPollingIntervalMillis(LDConfig.MIN_POLLING_INTERVAL_MILLIS - 1)
+                .build();
+
+        assertFalse(config.isStream());
+        assertFalse(config.isOffline());
+        assertFalse(config.isDisableBackgroundPolling());
+        assertEquals(LDConfig.MIN_POLLING_INTERVAL_MILLIS, config.getPollingIntervalMillis());
+        assertEquals(LDConfig.DEFAULT_BACKGROUND_POLLING_INTERVAL_MILLIS, PollingUpdater.backgroundPollingIntervalMillis);
+        assertEquals(LDConfig.MIN_POLLING_INTERVAL_MILLIS, config.getEventsFlushIntervalMillis());
+    }
+
+    @Test
+    public void TestBuilderStreamDisabledBackgroundPollingIntervalBelowMinimum() {
+        LDConfig config = new LDConfig.Builder()
+                .setStream(false)
+                .setBackgroundPollingIntervalMillis(LDConfig.MIN_POLLING_INTERVAL_MILLIS - 1)
+                .build();
+
+        assertFalse(config.isStream());
+        assertFalse(config.isOffline());
+        assertFalse(config.isDisableBackgroundPolling());
+        assertEquals(LDConfig.DEFAULT_POLLING_INTERVAL_MILLIS, config.getPollingIntervalMillis());
+        assertEquals(LDConfig.DEFAULT_POLLING_INTERVAL_MILLIS, PollingUpdater.backgroundPollingIntervalMillis);
+        assertEquals(LDConfig.DEFAULT_POLLING_INTERVAL_MILLIS, config.getEventsFlushIntervalMillis());
+    }
+}

--- a/launchdarkly-android-client/src/androidTest/java/com/launchdarkly/android/UserManagerTest.java
+++ b/launchdarkly-android-client/src/androidTest/java/com/launchdarkly/android/UserManagerTest.java
@@ -20,6 +20,7 @@ import org.junit.runner.RunWith;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 
 import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
 import static junit.framework.Assert.assertEquals;
@@ -60,7 +61,7 @@ public class UserManagerTest extends EasyMockSupport {
         jsonObject.addProperty("boolFlag1", expectedBoolFlagValue);
         jsonObject.addProperty("stringFlag1", expectedStringFlagValue);
 
-        ListenableFuture<Void> future = setUser("userKey", jsonObject);
+        Future<Void> future = setUser("userKey", jsonObject);
         future.get();
 
         SharedPreferences sharedPrefs = userManager.getCurrentUserSharedPrefs();
@@ -109,12 +110,12 @@ public class UserManagerTest extends EasyMockSupport {
         assertFlagValue(flagKey, user5);
     }
 
-    private ListenableFuture<Void> setUser(String userKey, JsonObject flags) {
+    private Future<Void> setUser(String userKey, JsonObject flags) {
         LDUser user = new LDUser.Builder(userKey).build();
         ListenableFuture<JsonObject> jsonObjectFuture = Futures.immediateFuture(flags);
         expect(fetcher.fetch(user)).andReturn(jsonObjectFuture);
         replayAll();
-        ListenableFuture<Void> future = userManager.setCurrentUser(user);
+        Future<Void> future = userManager.setCurrentUser(user);
         reset(fetcher);
         return future;
     }
@@ -128,7 +129,7 @@ public class UserManagerTest extends EasyMockSupport {
         expect(fetcher.fetch(user)).andReturn(failedFuture);
         replayAll();
 
-        ListenableFuture<Void> future = userManager.setCurrentUser(user);
+        Future<Void> future = userManager.setCurrentUser(user);
         try {
             future.get();
         } catch (ExecutionException e) {

--- a/launchdarkly-android-client/src/main/AndroidManifest.xml
+++ b/launchdarkly-android-client/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
     <application
         android:label="@string/app_name"
         android:supportsRtl="true">
-        <receiver android:name=".BackgroundUpdater" />
+        <receiver android:name=".PollingUpdater" />
         <receiver
             android:name=".ConnectivityReceiver"
             android:enabled="true">

--- a/launchdarkly-android-client/src/main/java/com/launchdarkly/android/ConnectivityReceiver.java
+++ b/launchdarkly-android-client/src/main/java/com/launchdarkly/android/ConnectivityReceiver.java
@@ -16,19 +16,23 @@ public class ConnectivityReceiver extends BroadcastReceiver {
             Log.d(TAG, "Connected to the internet");
             try {
                 LDClient ldClient = LDClient.get();
-                if (Foreground.get(context).isForeground()) {
-                    ldClient.startStreaming();
+                if (!ldClient.isOffline()) {
+                    if (Foreground.get(context).isForeground()) {
+                        ldClient.startForegroundUpdating();
+                    } else if (!ldClient.isDisableBackgroundPolling()){
+                        PollingUpdater.startBackgroundPolling(context);
+                    }
                 }
             } catch (LaunchDarklyException e) {
-                Log.e(TAG, "Tried to restart stream, but LDClient has not yet been initialized.");
+                Log.e(TAG, "Tried to restart foreground updating, but LDClient has not yet been initialized.");
             }
         } else {
             Log.d(TAG, "Not Connected to the internet");
             try {
                 LDClient ldClient = LDClient.get();
-                ldClient.stopStreaming();
+                ldClient.stopForegroundUpdating();
             } catch (LaunchDarklyException e) {
-                Log.e(TAG, "Tried to stop stream, but LDClient has not yet been initialized.");
+                Log.e(TAG, "Tried to stop foreground updating, but LDClient has not yet been initialized.");
             }
         }
     }

--- a/launchdarkly-android-client/src/main/java/com/launchdarkly/android/EventProcessor.java
+++ b/launchdarkly-android-client/src/main/java/com/launchdarkly/android/EventProcessor.java
@@ -17,6 +17,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
+import okhttp3.ConnectionPool;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -41,6 +42,7 @@ class EventProcessor implements Closeable {
         this.consumer = new Consumer(config);
 
         client = new OkHttpClient.Builder()
+                .connectionPool(new ConnectionPool(1, config.getEventsFlushIntervalMillis(), TimeUnit.MILLISECONDS))
                 .connectTimeout(config.getConnectionTimeoutMillis(), TimeUnit.MILLISECONDS)
                 .retryOnConnectionFailure(true)
                 .build();

--- a/launchdarkly-android-client/src/main/java/com/launchdarkly/android/HttpFeatureFlagFetcher.java
+++ b/launchdarkly-android-client/src/main/java/com/launchdarkly/android/HttpFeatureFlagFetcher.java
@@ -11,10 +11,12 @@ import com.google.gson.JsonParser;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import okhttp3.Cache;
 import okhttp3.Call;
 import okhttp3.Callback;
+import okhttp3.ConnectionPool;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -22,7 +24,7 @@ import okhttp3.Response;
 import static com.launchdarkly.android.Util.isInternetConnected;
 
 class HttpFeatureFlagFetcher implements FeatureFlagFetcher {
-    private static final String TAG = "LDFeatureFlagUpdater";
+    private static final String TAG = "LDFeatureFlagFetcher";
     private static final int MAX_CACHE_SIZE_BYTES = 500_000;
     private static HttpFeatureFlagFetcher instance;
 
@@ -60,6 +62,7 @@ class HttpFeatureFlagFetcher implements FeatureFlagFetcher {
         if (!isOffline && isInternetConnected(context)) {
             final OkHttpClient client = new OkHttpClient.Builder()
                     .cache(cache)
+                    .connectionPool(new ConnectionPool(1, config.getBackgroundPollingIntervalMillis(), TimeUnit.MILLISECONDS))
                     .retryOnConnectionFailure(true)
                     .build();
 

--- a/launchdarkly-android-client/src/main/java/com/launchdarkly/android/LDClient.java
+++ b/launchdarkly-android-client/src/main/java/com/launchdarkly/android/LDClient.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -44,21 +45,21 @@ public class LDClient implements LDClientInterface, Closeable {
     private volatile boolean isOffline = false;
 
     /**
-     * Initializes the singleton instance. The result is a {@link ListenableFuture} which
+     * Initializes the singleton instance. The result is a {@link Future} which
      * will complete once the client has been initialized with the latest feature flag values. For
      * immediate access to the Client (possibly with out of date feature flags), it is safe to ignore
      * the return value of this method, and afterward call {@link #get()}
      * <p/>
      * If the client has already been initialized, is configured for offline mode, or the device is
-     * not connected to the internet, this method will return a {@link ListenableFuture} that is
+     * not connected to the internet, this method will return a {@link Future} that is
      * already in the completed state.
      *
      * @param application Your Android application.
      * @param config      Configuration used to set up the client
      * @param user        The user used in evaluating feature flags
-     * @return a {@link ListenableFuture} which will complete once the client has been initialized.
+     * @return a {@link Future} which will complete once the client has been initialized.
      */
-    public static synchronized ListenableFuture<LDClient> init(Application application, LDConfig config, LDUser user) {
+    public static synchronized Future<LDClient> init(Application application, LDConfig config, LDUser user) {
         SettableFuture<LDClient> settableFuture = SettableFuture.create();
 
         if (instance != null) {
@@ -101,7 +102,7 @@ public class LDClient implements LDClientInterface, Closeable {
      */
     public static synchronized LDClient init(Application application, LDConfig config, LDUser user, int startWaitSeconds) {
         Log.i(TAG, "Initializing Client and waiting up to " + startWaitSeconds + " for initialization to complete");
-        ListenableFuture<LDClient> initFuture = init(application, config, user);
+        Future<LDClient> initFuture = init(application, config, user);
         try {
             return initFuture.get(startWaitSeconds, TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException e) {
@@ -196,7 +197,7 @@ public class LDClient implements LDClientInterface, Closeable {
      * @return Future whose success indicates this user's flag settings have been stored locally and are ready for evaluation.
      */
     @Override
-    public synchronized ListenableFuture<Void> identify(LDUser user) {
+    public synchronized Future<Void> identify(LDUser user) {
         if (user == null) {
             return Futures.immediateFailedFuture(new LaunchDarklyException("User cannot be null"));
         }
@@ -204,7 +205,7 @@ public class LDClient implements LDClientInterface, Closeable {
         if (user.getKey() == null) {
             Log.w(TAG, "identify called with null user or null user key!");
         }
-        ListenableFuture<Void> doneFuture = userManager.setCurrentUser(user);
+        Future<Void> doneFuture = userManager.setCurrentUser(user);
         sendEvent(new IdentifyEvent(user));
         return doneFuture;
     }

--- a/launchdarkly-android-client/src/main/java/com/launchdarkly/android/LDClientInterface.java
+++ b/launchdarkly-android-client/src/main/java/com/launchdarkly/android/LDClientInterface.java
@@ -1,6 +1,8 @@
 package com.launchdarkly.android;
 
 
+import android.content.Context;
+
 import com.google.gson.JsonElement;
 
 import java.io.Closeable;
@@ -39,4 +41,6 @@ public interface LDClientInterface extends Closeable {
     void registerFeatureFlagListener(String flagKey, FeatureFlagChangeListener listener);
 
     void unregisterFeatureFlagListener(String flagKey, FeatureFlagChangeListener listener);
+
+    boolean isDisableBackgroundPolling();
 }

--- a/launchdarkly-android-client/src/main/java/com/launchdarkly/android/LDConfig.java
+++ b/launchdarkly-android-client/src/main/java/com/launchdarkly/android/LDConfig.java
@@ -23,7 +23,7 @@ public class LDConfig {
     static final int DEFAULT_FLUSH_INTERVAL_MILLIS = 5000;
     static final int DEFAULT_CONNECTION_TIMEOUT_MILLIS = 10000;
     static final int DEFAULT_POLLING_INTERVAL_MILLIS = 300_000; // 5 minutes
-    static final int DEFAULT_BACKGROUND_POLLING_INTERVAL_MILLIS = 300_000; // 5 minutes
+    static final int DEFAULT_BACKGROUND_POLLING_INTERVAL_MILLIS = 900_000; // 15 minutes
     static final int MIN_POLLING_INTERVAL_MILLIS = 60_000; // 1 minute
 
     private final String mobileKey;

--- a/launchdarkly-android-client/src/main/java/com/launchdarkly/android/LDConfig.java
+++ b/launchdarkly-android-client/src/main/java/com/launchdarkly/android/LDConfig.java
@@ -1,6 +1,7 @@
 package com.launchdarkly.android;
 
 import android.net.Uri;
+import android.util.Log;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -10,27 +11,36 @@ import okhttp3.Request;
 
 public class LDConfig {
     private static final String TAG = "LDConfig";
-    public static final String USER_AGENT_HEADER_VALUE = "AndroidClient/" + BuildConfig.VERSION_NAME;
+    static final String USER_AGENT_HEADER_VALUE = "AndroidClient/" + BuildConfig.VERSION_NAME;
     static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
     static final Gson GSON = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
 
-    private static final Uri DEFAULT_BASE_Uri = Uri.parse("https://app.launchdarkly.com");
-    private static final Uri DEFAULT_EVENTS_Uri = Uri.parse("https://mobile.launchdarkly.com/mobile");
-    private static final Uri DEFAULT_STREAM_Uri = Uri.parse("https://stream.launchdarkly.com");
-    private static final int DEFAULT_EVENTS_CAPACITY = 100;
-    private static final int DEFAULT_FLUSH_INTERVAL_MILLIS = 5000;
-    private static final int DEFAULT_CONNECTION_TIMEOUT_MILLIS = 10000;
+    static final Uri DEFAULT_BASE_URI = Uri.parse("https://app.launchdarkly.com");
+    static final Uri DEFAULT_EVENTS_URI = Uri.parse("https://mobile.launchdarkly.com/mobile");
+    static final Uri DEFAULT_STREAM_URI = Uri.parse("https://clientstream.launchdarkly.com");
+
+    static final int DEFAULT_EVENTS_CAPACITY = 100;
+    static final int DEFAULT_FLUSH_INTERVAL_MILLIS = 5000;
+    static final int DEFAULT_CONNECTION_TIMEOUT_MILLIS = 10000;
+    static final int DEFAULT_POLLING_INTERVAL_MILLIS = 300_000; // 5 minutes
+    static final int DEFAULT_BACKGROUND_POLLING_INTERVAL_MILLIS = 300_000; // 5 minutes
+    static final int MIN_POLLING_INTERVAL_MILLIS = 60_000; // 1 minute
 
     private final String mobileKey;
 
     private final Uri baseUri;
     private final Uri eventsUri;
     private final Uri streamUri;
+
     private final int eventsCapacity;
     private final int eventsFlushIntervalMillis;
     private final int connectionTimeoutMillis;
+    private final int pollingIntervalMillis;
+    private final int backgroundPollingIntervalMillis;
 
+    private final boolean stream;
     private final boolean offline;
+    private final boolean disableBackgroundUpdating;
 
 
     public LDConfig(String mobileKey,
@@ -40,7 +50,11 @@ public class LDConfig {
                     int eventsCapacity,
                     int eventsFlushIntervalMillis,
                     int connectionTimeoutMillis,
-                    boolean offline) {
+                    boolean offline,
+                    boolean stream,
+                    int pollingIntervalMillis,
+                    int backgroundPollingIntervalMillis,
+                    boolean disableBackgroundUpdating) {
         this.mobileKey = mobileKey;
         this.baseUri = baseUri;
         this.eventsUri = eventsUri;
@@ -49,6 +63,10 @@ public class LDConfig {
         this.eventsFlushIntervalMillis = eventsFlushIntervalMillis;
         this.connectionTimeoutMillis = connectionTimeoutMillis;
         this.offline = offline;
+        this.stream = stream;
+        this.pollingIntervalMillis = pollingIntervalMillis;
+        this.backgroundPollingIntervalMillis = backgroundPollingIntervalMillis;
+        this.disableBackgroundUpdating = disableBackgroundUpdating;
     }
 
     public Request.Builder getRequestBuilder() {
@@ -89,58 +107,223 @@ public class LDConfig {
         return offline;
     }
 
+    public boolean isStream() {
+        return stream;
+    }
+
+    public int getPollingIntervalMillis() {
+        return pollingIntervalMillis;
+    }
+
+    public int getBackgroundPollingIntervalMillis() {
+        return backgroundPollingIntervalMillis;
+    }
+
+    public boolean isDisableBackgroundPolling() {
+        return disableBackgroundUpdating;
+    }
+
     public static class Builder {
         private String mobileKey;
-        private Uri baseUri = DEFAULT_BASE_Uri;
-        private Uri eventsUri = DEFAULT_EVENTS_Uri;
-        private Uri streamUri = DEFAULT_STREAM_Uri;
-        private int eventsCapacity = DEFAULT_EVENTS_CAPACITY;
-        private int eventsFlushIntervalMillis = DEFAULT_FLUSH_INTERVAL_MILLIS;
-        private int connectionTimeoutMillis = DEFAULT_CONNECTION_TIMEOUT_MILLIS;
-        private boolean offline = false;
 
+        private Uri baseUri = DEFAULT_BASE_URI;
+        private Uri eventsUri = DEFAULT_EVENTS_URI;
+        private Uri streamUri = DEFAULT_STREAM_URI;
+
+        private int eventsCapacity = DEFAULT_EVENTS_CAPACITY;
+        private int eventsFlushIntervalMillis = 0;
+        private int connectionTimeoutMillis = DEFAULT_CONNECTION_TIMEOUT_MILLIS;
+        private int pollingIntervalMillis = DEFAULT_POLLING_INTERVAL_MILLIS;
+        private int backgroundPollingIntervalMillis = DEFAULT_BACKGROUND_POLLING_INTERVAL_MILLIS;
+
+        private boolean offline = false;
+        private boolean stream = true;
+        private boolean disableBackgroundUpdating = false;
+
+
+        /**
+         * Sets the key for authenticating with LaunchDarkly. This is required unless you're using the client in offline mode.
+         *
+         * @param mobileKey Get this from the LaunchDarkly web app under Team Settings.
+         * @return
+         */
         public LDConfig.Builder setMobileKey(String mobileKey) {
             this.mobileKey = mobileKey;
             return this;
         }
 
+        /**
+         * Set the base uri for connecting to LaunchDarkly. You probably don't need to set this unless instructed by LaunchDarkly.
+         *
+         * @param baseUri
+         * @return
+         */
         public LDConfig.Builder setBaseUri(Uri baseUri) {
             this.baseUri = baseUri;
             return this;
         }
 
+        /**
+         * Set the events uri for sending analytics to LaunchDarkly. You probably don't need to set this unless instructed by LaunchDarkly.
+         *
+         * @param eventsUri
+         * @return
+         */
         public LDConfig.Builder setEventsUri(Uri eventsUri) {
             this.eventsUri = eventsUri;
             return this;
         }
 
+        /**
+         * Set the stream uri for connecting to the flag update stream. You probably don't need to set this unless instructed by LaunchDarkly.
+         *
+         * @param streamUri
+         * @return
+         */
         public LDConfig.Builder setStreamUri(Uri streamUri) {
             this.streamUri = streamUri;
             return this;
         }
 
+        /**
+         * Sets the max number of events to queue before sending them to LaunchDarkly. Default: {@value LDConfig#DEFAULT_EVENTS_CAPACITY}
+         *
+         * @param eventsCapacity
+         * @return
+         */
         public LDConfig.Builder setEventsCapacity(int eventsCapacity) {
             this.eventsCapacity = eventsCapacity;
             return this;
         }
 
+        /**
+         * Sets the maximum amount of time in milliseconds to wait in between sending analytics events to LaunchDarkly.
+         * Default: {@value LDConfig#DEFAULT_FLUSH_INTERVAL_MILLIS}
+         *
+         * @param eventsFlushIntervalMillis
+         * @return
+         */
         public LDConfig.Builder setEventsFlushIntervalMillis(int eventsFlushIntervalMillis) {
             this.eventsFlushIntervalMillis = eventsFlushIntervalMillis;
             return this;
         }
 
+
+        /**
+         * Sets the timeout in milliseconds when connecting to LaunchDarkly. Default: {@value LDConfig#DEFAULT_CONNECTION_TIMEOUT_MILLIS}
+         *
+         * @param connectionTimeoutMillis
+         * @return
+         */
         public LDConfig.Builder setConnectionTimeoutMillis(int connectionTimeoutMillis) {
             this.connectionTimeoutMillis = connectionTimeoutMillis;
             return this;
         }
 
+
+        /**
+         * Enables or disables real-time streaming flag updates. Default: true. When set to false,
+         * an efficient caching polling mechanism is used.
+         *
+         * @param enabled
+         * @return
+         */
+        public LDConfig.Builder setStream(boolean enabled) {
+            this.stream = enabled;
+            return this;
+        }
+
+        /**
+         * Only relevant when setStream(false) is called. Sets the interval between feature flag updates. Default: {@link LDConfig#DEFAULT_POLLING_INTERVAL_MILLIS}
+         * Minimum value: {@link LDConfig#MIN_POLLING_INTERVAL_MILLIS}. When set, this will also set the eventsFlushIntervalMillis to the same value.
+         *
+         * @param pollingIntervalMillis
+         * @return
+         */
+        public LDConfig.Builder setPollingIntervalMillis(int pollingIntervalMillis) {
+            this.pollingIntervalMillis = pollingIntervalMillis;
+            return this;
+        }
+
+        /**
+         * Sets the interval in milliseconds that twe will poll for flag updates when your app is in the background. Default:
+         * {@link LDConfig#DEFAULT_BACKGROUND_POLLING_INTERVAL_MILLIS}
+         *
+         * @param backgroundPollingIntervalMillis
+         */
+        public LDConfig.Builder setBackgroundPollingIntervalMillis(int backgroundPollingIntervalMillis) {
+            this.backgroundPollingIntervalMillis = backgroundPollingIntervalMillis;
+            return this;
+        }
+
+        /**
+         * Disables feature flag updates when your app is in the background. Default: false
+         *
+         * @param disableBackgroundUpdating
+         */
+        public LDConfig.Builder setDisableBackgroundUpdating(boolean disableBackgroundUpdating) {
+            this.disableBackgroundUpdating = disableBackgroundUpdating;
+            return this;
+        }
+
+        /**
+         * Disables all network calls from the LaunchDarkly Client. Once the client has been created,
+         * use the {@link LDClient#setOffline()} method to disable network calls. Default: false
+         *
+         * @param offline
+         * @return
+         */
         public LDConfig.Builder setOffline(boolean offline) {
             this.offline = offline;
             return this;
         }
 
         public LDConfig build() {
-            return new LDConfig(mobileKey, baseUri, eventsUri, streamUri, eventsCapacity, eventsFlushIntervalMillis, connectionTimeoutMillis, offline);
+            if (stream && !disableBackgroundUpdating) {
+                if (backgroundPollingIntervalMillis < MIN_POLLING_INTERVAL_MILLIS) {
+                    Log.w(TAG, "BackgroundPollingIntervalMillis: " + backgroundPollingIntervalMillis +
+                            " was set below the minimum allowed: " + MIN_POLLING_INTERVAL_MILLIS + ". Ignoring and using minimum value.");
+                    backgroundPollingIntervalMillis = MIN_POLLING_INTERVAL_MILLIS;
+                }
+            } else
+            {
+                if (pollingIntervalMillis < MIN_POLLING_INTERVAL_MILLIS) {
+                    Log.w(TAG, "setPollingIntervalMillis: " + pollingIntervalMillis
+                            + " was set below the allowed minimum of: " + MIN_POLLING_INTERVAL_MILLIS + ". Ignoring and using minimum value.");
+                    pollingIntervalMillis = MIN_POLLING_INTERVAL_MILLIS;
+                }
+
+                if (!disableBackgroundUpdating && backgroundPollingIntervalMillis < pollingIntervalMillis) {
+                    Log.w(TAG, "BackgroundPollingIntervalMillis: " + backgroundPollingIntervalMillis +
+                            " was set below the foreground polling interval: " + pollingIntervalMillis + ". Ignoring and using polling interval value for background polling.");
+                    backgroundPollingIntervalMillis = pollingIntervalMillis;
+                }
+
+                if (eventsFlushIntervalMillis == 0) {
+                    eventsFlushIntervalMillis = pollingIntervalMillis;
+                    Log.d(TAG, "Streaming is disabled, so we're setting the events flush interval to the polling interval value: " + pollingIntervalMillis);
+                }
+            }
+
+            if (eventsFlushIntervalMillis == 0) {
+                eventsFlushIntervalMillis = DEFAULT_FLUSH_INTERVAL_MILLIS;
+            }
+
+            PollingUpdater.backgroundPollingIntervalMillis = backgroundPollingIntervalMillis;
+
+            return new LDConfig(
+                    mobileKey,
+                    baseUri,
+                    eventsUri,
+                    streamUri,
+                    eventsCapacity,
+                    eventsFlushIntervalMillis,
+                    connectionTimeoutMillis,
+                    offline,
+                    stream,
+                    pollingIntervalMillis,
+                    backgroundPollingIntervalMillis,
+                    disableBackgroundUpdating);
         }
     }
 }

--- a/launchdarkly-android-client/src/main/java/com/launchdarkly/android/LDUser.java
+++ b/launchdarkly-android-client/src/main/java/com/launchdarkly/android/LDUser.java
@@ -3,14 +3,12 @@ package com.launchdarkly.android;
 
 import android.os.Build;
 import android.util.Base64;
+import android.util.Log;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.annotations.Expose;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.List;
@@ -32,7 +30,7 @@ import static com.launchdarkly.android.LDConfig.GSON;
  * launch a feature to the top 10% of users on a site.
  */
 public class LDUser {
-    private static final Logger logger = LoggerFactory.getLogger(LDUser.class);
+    private static final String TAG = "LDUser";
 
     @Expose
     private final JsonPrimitive key;
@@ -62,7 +60,7 @@ public class LDUser {
 
     protected LDUser(Builder builder) {
         if (builder.key == null || builder.key.equals("")) {
-            logger.warn("User was created with null/empty key. " +
+            Log.w(TAG, "User was created with null/empty key. " +
                     "Using device-unique anonymous user key: " + LDClient.getInstanceId());
             this.key = new JsonPrimitive(LDClient.getInstanceId());
             this.anonymous = new JsonPrimitive(true);
@@ -227,7 +225,7 @@ public class LDUser {
                 List<LDCountryCode> codes = LDCountryCode.findByName("^" + Pattern.quote(s) + ".*");
 
                 if (codes.isEmpty()) {
-                    logger.warn("Invalid country. Expected valid ISO-3166-1 code: " + s);
+                    Log.w(TAG, "Invalid country. Expected valid ISO-3166-1 code: " + s);
                 } else if (codes.size() > 1) {
                     // See if any of the codes is an exact match
                     for (LDCountryCode c : codes) {
@@ -236,7 +234,7 @@ public class LDUser {
                             return this;
                         }
                     }
-                    logger.warn("Ambiguous country. Provided code matches multiple countries: " + s);
+                    Log.w(TAG, "Ambiguous country. Provided code matches multiple countries: " + s);
                     country = codes.get(0);
                 } else {
                     country = codes.get(0);
@@ -434,7 +432,7 @@ public class LDUser {
         private void checkCustomAttribute(String key) {
             for (UserAttribute a : UserAttribute.values()) {
                 if (a.name().equals(key)) {
-                    logger.warn("Built-in attribute key: " + key + " added as custom attribute! This custom attribute will be ignored during Feature Flag evaluation");
+                    Log.w(TAG, "Built-in attribute key: " + key + " added as custom attribute! This custom attribute will be ignored during Feature Flag evaluation");
                     return;
                 }
             }

--- a/launchdarkly-android-client/src/main/java/com/launchdarkly/android/PollingUpdateProcessor.java
+++ b/launchdarkly-android-client/src/main/java/com/launchdarkly/android/PollingUpdateProcessor.java
@@ -1,0 +1,38 @@
+package com.launchdarkly.android;
+
+
+import android.content.Context;
+import android.util.Log;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+class PollingUpdateProcessor implements UpdateProcessor {
+    private final String TAG = "LDPollingUpdater";
+    private final Context context;
+    private final UserManager userManager;
+    private final LDConfig config;
+
+    PollingUpdateProcessor(Context context, UserManager userManager, LDConfig config) {
+        this.context = context;
+        this.userManager = userManager;
+        this.config = config;
+    }
+
+    @Override
+    public ListenableFuture<Void> start() {
+        Log.d(TAG, "Starting PollingUpdateProcessor");
+        PollingUpdater.startPolling(context, config.getPollingIntervalMillis(), config.getPollingIntervalMillis());
+        return userManager.updateCurrentUser();
+    }
+
+    @Override
+    public void stop() {
+        Log.d(TAG, "Stopping PollingUpdateProcessor");
+        PollingUpdater.stop(context);
+    }
+
+    @Override
+    public boolean isInitialized() {
+        return userManager.isInitialized();
+    }
+}

--- a/launchdarkly-android-client/src/main/java/com/launchdarkly/android/StreamProcessor.java
+++ b/launchdarkly-android-client/src/main/java/com/launchdarkly/android/StreamProcessor.java
@@ -52,6 +52,11 @@ class StreamProcessor implements Closeable {
                 }
 
                 @Override
+                public void onClosed() throws Exception {
+
+                }
+
+                @Override
                 public void onMessage(String name, MessageEvent event) throws Exception {
                     Log.d(TAG, "onMessage: name: " + name + " event: " + event.getData());
                     if (!initialized.getAndSet(true)) {
@@ -60,6 +65,11 @@ class StreamProcessor implements Closeable {
                     } else {
                         userManager.updateCurrentUser();
                     }
+                }
+
+                @Override
+                public void onComment(String comment) throws Exception {
+
                 }
 
                 @Override

--- a/launchdarkly-android-client/src/main/java/com/launchdarkly/android/StreamUpdateProcessor.java
+++ b/launchdarkly-android-client/src/main/java/com/launchdarkly/android/StreamUpdateProcessor.java
@@ -17,7 +17,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import okhttp3.Headers;
 
-class StreamProcessor implements Closeable {
+class StreamUpdateProcessor implements UpdateProcessor {
     private static final String TAG = "LDStreamProcessor";
 
     private EventSource es;
@@ -27,18 +27,19 @@ class StreamProcessor implements Closeable {
     private volatile boolean running = false;
     private final URI uri;
 
-    StreamProcessor(LDConfig config, UserManager userManager) {
+    StreamUpdateProcessor(LDConfig config, UserManager userManager) {
         this.config = config;
         this.userManager = userManager;
         uri = URI.create(config.getStreamUri().toString() + "/mping");
     }
 
-    synchronized ListenableFuture<Void> start() {
+    public synchronized ListenableFuture<Void> start() {
         final SettableFuture<Void> initFuture = SettableFuture.create();
         initialized.set(false);
 
         if (!running) {
-            close();
+            stop();
+            Log.d(TAG, "Starting.");
             Headers headers = new Headers.Builder()
                     .add("Authorization", config.getMobileKey())
                     .add("User-Agent", LDConfig.USER_AGENT_HEADER_VALUE)
@@ -53,7 +54,7 @@ class StreamProcessor implements Closeable {
 
                 @Override
                 public void onClosed() throws Exception {
-
+                    Log.i(TAG, "Closed LaunchDarkly EventStream");
                 }
 
                 @Override
@@ -98,14 +99,8 @@ class StreamProcessor implements Closeable {
         return initFuture;
     }
 
-    synchronized void stop() {
-        close();
-        running = false;
-    }
-
-
-    @Override
-    public void close() {
+    public synchronized void stop() {
+        Log.d(TAG, "Stopping.");
         if (es != null) {
             try {
                 es.close();
@@ -113,9 +108,11 @@ class StreamProcessor implements Closeable {
                 Log.e(TAG, "Exception caught when closing stream.", e);
             }
         }
+        running = false;
+        Log.d(TAG, "Stopped.");
     }
 
-    boolean isInitialized() {
+    public boolean isInitialized() {
         return initialized.get();
     }
 }

--- a/launchdarkly-android-client/src/main/java/com/launchdarkly/android/UpdateProcessor.java
+++ b/launchdarkly-android-client/src/main/java/com/launchdarkly/android/UpdateProcessor.java
@@ -1,0 +1,26 @@
+package com.launchdarkly.android;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+interface UpdateProcessor {
+
+    /**
+     * Starts the UpdateProcessor.
+     *
+     * @return {@link ListenableFuture}'s completion status indicating when the UpdateProcessor has been initialized.
+     */
+    ListenableFuture<Void> start();
+
+    /**
+     * Stops the UpdateProcessor.
+     * An UpdateProcessor can be stopped and started multiple times.
+     */
+    void stop();
+
+    /**
+     * Returns true once the UpdateProcessor has been initialized and will never return false again.
+     *
+     * @return
+     */
+    boolean isInitialized();
+}

--- a/launchdarkly-android-client/src/main/java/com/launchdarkly/android/UserManager.java
+++ b/launchdarkly-android-client/src/main/java/com/launchdarkly/android/UserManager.java
@@ -198,7 +198,9 @@ class UserManager {
         for (Map.Entry<String, JsonElement> entry : flags.entrySet()) {
             JsonElement v = entry.getValue();
             String key = entry.getKey();
-            if (v.isJsonPrimitive() && v.getAsJsonPrimitive().isBoolean()) {
+            if (v.isJsonObject() || v.isJsonArray()) {
+                currentEditor.putString(key, v.toString());
+            } else if (v.isJsonPrimitive() && v.getAsJsonPrimitive().isBoolean()) {
                 currentEditor.putBoolean(key, v.getAsBoolean());
             } else if (v.isJsonPrimitive() && v.getAsJsonPrimitive().isNumber()) {
                 currentEditor.putFloat(key, v.getAsFloat());

--- a/launchdarkly-android-client/src/main/java/com/launchdarkly/android/UserManager.java
+++ b/launchdarkly-android-client/src/main/java/com/launchdarkly/android/UserManager.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Future;
 
 /**
  * Persists and retrieves feature flag values for different {@link LDUser}s.
@@ -89,12 +90,12 @@ class UserManager {
      *
      * @param user
      */
-    ListenableFuture<Void> setCurrentUser(final LDUser user) {
+    Future<Void> setCurrentUser(final LDUser user) {
         String userBase64 = user.getAsUrlSafeBase64();
         Log.d(TAG, "Setting current user to: [" + userBase64 + "] [" + userBase64ToJson(userBase64) + "]");
         currentUser = user;
         currentUserSharedPrefs = loadSharedPrefsForUser(userBase64);
-        ListenableFuture<Void> updateFuture = updateCurrentUser();
+        Future<Void> updateFuture = updateCurrentUser();
         usersSharedPrefs.edit()
                 .putLong(userBase64, System.currentTimeMillis())
                 .apply();

--- a/launchdarkly-android-client/src/main/java/com/launchdarkly/android/UserManager.java
+++ b/launchdarkly-android-client/src/main/java/com/launchdarkly/android/UserManager.java
@@ -39,6 +39,7 @@ class UserManager {
     private static UserManager instance;
     private final FeatureFlagFetcher fetcher;
     private final String sharedPrefsBaseKey;
+    private volatile boolean initialized = false;
 
     // The active user is the one that we track for changes to enable listeners.
     // Its values will mirror the current user, but it is a different SharedPreferences
@@ -135,6 +136,7 @@ class UserManager {
         Futures.addCallback(fetchFuture, new FutureCallback<JsonObject>() {
             @Override
             public void onSuccess(JsonObject result) {
+                initialized = true;
                 saveFlagSettings(result);
             }
 
@@ -320,6 +322,10 @@ class UserManager {
 
     private static String userBase64ToJson(String base64) {
         return new String(Base64.decode(base64, Base64.URL_SAFE));
+    }
+
+    boolean isInitialized() {
+        return initialized;
     }
 
     class EntryComparator implements Comparator<Map.Entry<String, Long>> {


### PR DESCRIPTION
### Added
- More configurable flag update mechanisms including the ability to disable streaming. See README.md for details.

### Changed
- API BREAKING CHANGE: Guava ListenableFuture is no longer returned from LDClient. Instead we're returning java.util.concurrent.Future.
- Added configurable background polling.
- Improved Json variation handling.
- Improved stream connection lifecycle management.
- Removed SLF4J logger in LDUser.
- Updated suggested Proguard rules for a smaller footprint.

### Fixed
- [Update to Latest version of OkHttp](https://github.com/launchdarkly/android-client/issues/20)