### PR TITLE
Fix the potential ConcurrentModificationException in unregisterListener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 All notable changes to the LaunchDarkly Android SDK will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [2.0.4] - 2017-05-26
+### Changed
+- Modified default and minimum background polling intervals.
+- Improved http client lifecycle management.
+- Improved offline saving of flags when switching users.
+
 ## [2.0.3] - 2017-05-18
 ### Changed
 - Even better thread safety in UserManager when removing change listeners.

--- a/launchdarkly-android-client/build.gradle
+++ b/launchdarkly-android-client/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'com.getkeepsafe.dexcount'
 
 allprojects {
     group = 'com.launchdarkly'
-    version = '2.0.3'
+    version = '2.0.4'
     sourceCompatibility = 1.7
     targetCompatibility = 1.7
 }


### PR DESCRIPTION
A customer reported a `ConcurrentModificationException` in `unregisterListener`. I could reproduce this issue by calling `unregisterListener` after registering the same listener twice. I fixed this issue by using an Iterator when removing the listener and also storing unique listeners.