### PR TITLE
Version 2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 All notable changes to the LaunchDarkly Android SDK will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [2.5.1] - 2018-08-13
+### Fixed
+- `ClassCastException` when calling `variation` methods due to internal storage schema changes between releases 2.3.x and 2.4.0.
+- `LDUser.Builder.custom()` no longer returns `UnsupportedOperationException`.
+
 ## [2.5.0] - 2018-06-12
 ### Changed
 - `LDClient#identify(LDUser)` now returns a `Future<Void>` so that the app can be notified when flag values have been refreshed for the updated user.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Check out the included example app, or follow things here:
 1. Declare this dependency:
 
 	```
-	compile 'com.launchdarkly:launchdarkly-android-client:2.5.0'
+	compile 'com.launchdarkly:launchdarkly-android-client:2.5.1'
 	```  
 1. In your application configure and initialize the client:
 

--- a/launchdarkly-android-client/build.gradle
+++ b/launchdarkly-android-client/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'io.codearte.nexus-staging'
 
 allprojects {
     group = 'com.launchdarkly'
-    version = '2.5.0'
+    version = '2.5.1'
     sourceCompatibility = 1.7
     targetCompatibility = 1.7
 }

--- a/launchdarkly-android-client/src/androidTest/java/com/launchdarkly/android/LDUserTest.java
+++ b/launchdarkly-android-client/src/androidTest/java/com/launchdarkly/android/LDUserTest.java
@@ -58,4 +58,15 @@ public class LDUserTest {
         Assert.assertEquals(privateAttributeNames.size(), 0);
     }
 
+    @Test
+    public void testModifyExistingUserPrivateAttributes() {
+        LDUser.Builder builder = new LDUser.Builder("1")
+                .custom("k1", "v1");
+        LDUser user = builder.build();
+        LDUser.Builder existingUserBuilder = new LDUser.Builder(user);
+
+        // An UnsupportedOperationException was previously being thrown in this case
+        existingUserBuilder.custom("k2", "v2");
+    }
+
 }

--- a/launchdarkly-android-client/src/main/java/com/launchdarkly/android/LDUser.java
+++ b/launchdarkly-android-client/src/main/java/com/launchdarkly/android/LDUser.java
@@ -254,7 +254,7 @@ public class LDUser {
             this.name = user.getName() != null ? user.getName().getAsString() : null;
             this.avatar = user.getAvatar() != null ? user.getAvatar().getAsString() : null;
             this.country = user.getCountry() != null ? LDCountryCode.valueOf(user.getCountry().getAsString()) : null;
-            this.custom = user.custom;
+            this.custom = new HashMap<>(user.custom);
 
             this.privateAttributeNames = new HashSet<>(user.getPrivateAttributeNames());
         }

--- a/launchdarkly-android-client/src/main/java/com/launchdarkly/android/response/BaseUserSharedPreferences.java
+++ b/launchdarkly-android-client/src/main/java/com/launchdarkly/android/response/BaseUserSharedPreferences.java
@@ -1,5 +1,6 @@
 package com.launchdarkly.android.response;
 
+import android.annotation.SuppressLint;
 import android.content.SharedPreferences;
 import android.support.annotation.Nullable;
 
@@ -32,9 +33,19 @@ abstract class BaseUserSharedPreferences {
         return asJsonObject.get(keyOfValueToExtract);
     }
 
+    @SuppressLint("ApplySharedPref")
     @Nullable
     JsonObject getValueAsJsonObject(String flagResponseKey) {
-        String storedFlag = sharedPreferences.getString(flagResponseKey, null);
+        String storedFlag;
+        try {
+            storedFlag = sharedPreferences.getString(flagResponseKey, null);
+        } catch (ClassCastException castException) {
+            // An old version of shared preferences is stored, so clear it.
+            // The flag responses will get re-synced with the server
+            sharedPreferences.edit().clear().commit();
+            return null;
+        }
+
         if (storedFlag == null) {
             return null;
         }


### PR DESCRIPTION
* `ClassCastException` when calling `variation` methods due to internal storage schema changes between releases 2.3.x and 2.4.0
* `LDUser.Builder.custom()` no longer returns `UnsupportedOperationException`