### PR TITLE
Added support for TLS v1.2 on pre-Lollipop devices

### DIFF
--- a/launchdarkly-android-client/src/main/java/com/launchdarkly/android/EventProcessor.java
+++ b/launchdarkly-android-client/src/main/java/com/launchdarkly/android/EventProcessor.java
@@ -49,7 +49,7 @@ class EventProcessor implements Closeable {
         this.consumer = new Consumer(config);
         this.summaryEventSharedPreferences = summaryEventSharedPreferences;
 
-        client = new OkHttpClient.Builder()
+        client = HttpClientBuilderGenerator.getOkHttpClientBuilder()
                 .connectionPool(new ConnectionPool(1, config.getEventsFlushIntervalMillis() * 2, TimeUnit.MILLISECONDS))
                 .connectTimeout(config.getConnectionTimeoutMillis(), TimeUnit.MILLISECONDS)
                 .retryOnConnectionFailure(true)

--- a/launchdarkly-android-client/src/main/java/com/launchdarkly/android/HttpClientBuilderGenerator.java
+++ b/launchdarkly-android-client/src/main/java/com/launchdarkly/android/HttpClientBuilderGenerator.java
@@ -19,7 +19,8 @@ class HttpClientBuilderGenerator {
     private static OkHttpClient.Builder okHttpClientBuilder = new OkHttpClient.Builder();
 
     static {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {     // Older than LOLLIPOP does not have TLSv1.2 enabled by default
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN        // Older than JELLY_BEAN does not have TLSv1.2 support at all
+            && Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {     // Older than LOLLIPOP does not have TLSv1.2 enabled by default
             try {
                 // This is the main fix here
                 okHttpClientBuilder.sslSocketFactory(new TLSV12SocketFactory(), generateTLSv12TrustManager());

--- a/launchdarkly-android-client/src/main/java/com/launchdarkly/android/HttpClientBuilderGenerator.java
+++ b/launchdarkly-android-client/src/main/java/com/launchdarkly/android/HttpClientBuilderGenerator.java
@@ -1,0 +1,46 @@
+package com.launchdarkly.android;
+
+import android.os.Build;
+
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+
+import okhttp3.OkHttpClient;
+import timber.log.Timber;
+
+class HttpClientBuilderGenerator {
+    private static OkHttpClient.Builder okHttpClientBuilder = new OkHttpClient.Builder();
+
+    static {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {     // Older than LOLLIPOP does not have TLSv1.2 enabled by default
+            try {
+                // This is the main fix here
+                okHttpClientBuilder.sslSocketFactory(new TLSV12SocketFactory(), generateTLSv12TrustManager());
+            } catch (KeyManagementException | IllegalStateException | NoSuchAlgorithmException | KeyStoreException ex) {
+                ex.printStackTrace();
+                Timber.e(ex, "TLS generator failure!");
+            }
+        }
+    }
+
+    static OkHttpClient.Builder getOkHttpClientBuilder() {
+        return okHttpClientBuilder;
+    }
+
+    private static X509TrustManager generateTLSv12TrustManager() throws NoSuchAlgorithmException, KeyStoreException {
+        TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        trustManagerFactory.init((KeyStore)null);
+        TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
+        if (trustManagers.length == 1 && trustManagers[0] instanceof X509TrustManager) {
+            return (X509TrustManager)trustManagers[0];
+        }
+        throw new IllegalStateException("Unexpected default trust managers: " + Arrays.toString(trustManagers));
+    }
+}

--- a/launchdarkly-android-client/src/main/java/com/launchdarkly/android/HttpFeatureFlagFetcher.java
+++ b/launchdarkly-android-client/src/main/java/com/launchdarkly/android/HttpFeatureFlagFetcher.java
@@ -56,7 +56,7 @@ class HttpFeatureFlagFetcher implements FeatureFlagFetcher {
         File cacheDir = context.getCacheDir();
         Timber.d("Using cache at: %s", cacheDir.getAbsolutePath());
 
-        client = new OkHttpClient.Builder()
+        client = HttpClientBuilderGenerator.getOkHttpClientBuilder()
                 .cache(new Cache(cacheDir, MAX_CACHE_SIZE_BYTES))
                 .connectionPool(new ConnectionPool(1, config.getBackgroundPollingIntervalMillis() * 2, TimeUnit.MILLISECONDS))
                 .retryOnConnectionFailure(true)

--- a/launchdarkly-android-client/src/main/java/com/launchdarkly/android/TLSV12SocketFactory.java
+++ b/launchdarkly-android-client/src/main/java/com/launchdarkly/android/TLSV12SocketFactory.java
@@ -1,0 +1,73 @@
+package com.launchdarkly.android;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+/**
+ * This class is here to support activating TLS v1.2 on JellyBean and KitKat devices.
+ * JellyBean and KitKat devices ship with TLS v1.2 protocol support installed but disabled by default.
+ * This code supports switching the TLS protocol to TLS v1.2-only, and should only be used by JellyBean and KitKat devices
+ */
+class TLSV12SocketFactory extends SSLSocketFactory {
+    private SSLSocketFactory delegate;
+
+    TLSV12SocketFactory() throws KeyManagementException, NoSuchAlgorithmException {
+        SSLContext context = SSLContext.getInstance("TLS");
+        context.init(null, null, null);
+        delegate = context.getSocketFactory();
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return delegate.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return delegate.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket() throws IOException {
+        return enableTLSOnSocket(delegate.createSocket());
+    }
+
+    @Override
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+        return enableTLSOnSocket(delegate.createSocket(s, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException {
+        return enableTLSOnSocket(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException {
+        return enableTLSOnSocket(delegate.createSocket(host, port, localHost, localPort));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return enableTLSOnSocket(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+        return enableTLSOnSocket(delegate.createSocket(address, port, localAddress, localPort));
+    }
+
+    private Socket enableTLSOnSocket(Socket socket) {
+        if (socket instanceof SSLSocket) {
+            ((SSLSocket)socket).setEnabledProtocols(new String[]{"TLSv1.1", "TLSv1.2"});
+        }
+        return socket;
+    }
+}


### PR DESCRIPTION
Android devices _subsequent to_ *Ice Cream Sandwich* (4.0/API level 14) and _prior to_ *Lollipop* (5.0/API level 21) ship with TLS v1.2 protocol and cipher support available, but it is not enabled by default. This change will enable this protocol for these devices, so they can continue to use LaunchDarkly even if the service-side requires TLS v1.2.
