### PR TITLE
Add Apache license body to repo

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,13 @@
+Copyright 2016 Catamorphic, Co.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
This repo has referenced the Apache license since [2016](https://github.com/launchdarkly/android-client/commit/0e49c40712a0d21f4dca4509836a30859fb10a5b#diff-db8c608de96cfcc5c26c05958eb82627R72), but we didn't include the license body in-line. This PR rectifies that.