### PR TITLE
feat: deprecating init without timeout

### DIFF
--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClient.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClient.java
@@ -232,7 +232,7 @@ public class LDClient implements LDClientInterface, Closeable {
         initSharedLogger(config);
         getSharedLogger().info("Initializing Client and waiting up to {} for initialization to complete", startWaitSeconds);
         if (startWaitSeconds >= EXCESSIVE_INIT_WAIT_SECONDS) {
-            getSharedLogger().warn("LDClient.init called with high start wait time parameter of {} seconds.", startWaitSeconds);
+            getSharedLogger().warn("LDClient.init called with start wait time parameter of {} seconds.  We recommend a timeout of less than {} seconds.", startWaitSeconds, EXCESSIVE_INIT_WAIT_SECONDS);
         }
 
         Future<LDClient> initFuture = init(application, config, context);


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality - N/A

- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)

- [ ] I have validated my changes against all supported platform versions - N/A, no platform dependencies changed and CI tests have sufficient coverage.

**Related issues**
238624

BEGIN_COMMIT_OVERRIDE
feat: deprecating init without timeout
END_COMMIT_OVERRIDE