### PR TITLE
feat: Reduce streaming DNS failures with stale-fallback DNS cache

### DIFF
--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/CachingDns.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/CachingDns.java
@@ -6,6 +6,8 @@ import com.launchdarkly.logging.LDLogger;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -42,7 +44,7 @@ final class CachingDns implements Dns {
         final long expiresAtMs;
 
         CacheEntry(List<InetAddress> addresses, long expiresAtMs) {
-            this.addresses = addresses;
+            this.addresses = Collections.unmodifiableList(new ArrayList<>(addresses));
             this.expiresAtMs = expiresAtMs;
         }
 

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/CachingDns.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/CachingDns.java
@@ -93,7 +93,12 @@ final class CachingDns implements Dns {
     }
 
     private void evictExpired(long now) {
-        cache.entrySet().removeIf(e -> e.getValue().isExpired(now));
+        java.util.Iterator<java.util.Map.Entry<String, CacheEntry>> it = cache.entrySet().iterator();
+        while (it.hasNext()) {
+            if (it.next().getValue().isExpired(now)) {
+                it.remove();
+            }
+        }
     }
 
     @VisibleForTesting

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/CachingDns.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/CachingDns.java
@@ -1,0 +1,91 @@
+package com.launchdarkly.sdk.android;
+
+import androidx.annotation.VisibleForTesting;
+
+import com.launchdarkly.logging.LDLogger;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+import okhttp3.Dns;
+
+/**
+ * A DNS resolver that caches successful lookups and falls back to stale cache
+ * entries when a fresh resolution fails. This is particularly useful on mobile
+ * networks where DNS can be unreliable during network transitions.
+ * <p>
+ * On API 34+ Android provides native stale-DNS support via
+ * {@code DnsOptions.StaleDnsOptions}, so this class is only used on older
+ * platform versions. See {@code ComponentsImpl.StreamingDataSourceBuilderImpl}
+ * for the conditional wiring.
+ * <p>
+ * Instances of this class are thread-safe and designed to be shared across
+ * multiple OkHttpClient instances so that the cache persists even when the
+ * HTTP client is recreated (e.g. on EventSource reconnections).
+ */
+final class CachingDns implements Dns {
+
+    @VisibleForTesting
+    static final long DEFAULT_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+    private final Dns delegate;
+    private final long ttlMs;
+    private final LDLogger logger;
+    private final ConcurrentHashMap<String, CacheEntry> cache = new ConcurrentHashMap<>();
+
+    static final class CacheEntry {
+        final List<InetAddress> addresses;
+        final long expiresAtMs;
+
+        CacheEntry(List<InetAddress> addresses, long expiresAtMs) {
+            this.addresses = addresses;
+            this.expiresAtMs = expiresAtMs;
+        }
+
+        boolean isExpired(long nowMs) {
+            return nowMs >= expiresAtMs;
+        }
+    }
+
+    CachingDns(Dns delegate, long ttlMs, LDLogger logger) {
+        this.delegate = delegate;
+        this.ttlMs = ttlMs;
+        this.logger = logger;
+    }
+
+    CachingDns(LDLogger logger) {
+        this(Dns.SYSTEM, DEFAULT_TTL_MS, logger);
+    }
+
+    @Override
+    public List<InetAddress> lookup(String hostname) throws UnknownHostException {
+        long now = System.currentTimeMillis();
+        CacheEntry entry = cache.get(hostname);
+
+        if (entry != null && !entry.isExpired(now)) {
+            return entry.addresses;
+        }
+
+        try {
+            List<InetAddress> addresses = delegate.lookup(hostname);
+            cache.put(hostname, new CacheEntry(addresses, now + ttlMs));
+            return addresses;
+        } catch (UnknownHostException e) {
+            if (entry != null) {
+                logger.warn(
+                        "DNS lookup failed for {}, falling back to cached address (age {}ms)",
+                        hostname, now - (entry.expiresAtMs - ttlMs)
+                );
+                return entry.addresses;
+            }
+            throw e;
+        }
+    }
+
+    @VisibleForTesting
+    CacheEntry getCacheEntry(String hostname) {
+        return cache.get(hostname);
+    }
+}

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/CachingDns.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/CachingDns.java
@@ -18,10 +18,10 @@ import okhttp3.Dns;
  * entries when a fresh resolution fails. This is particularly useful on mobile
  * networks where DNS can be unreliable during network transitions.
  * <p>
- * On API 34+ Android provides native stale-DNS support via
- * {@code DnsOptions.StaleDnsOptions}, so this class is only used on older
- * platform versions. See {@code ComponentsImpl.StreamingDataSourceBuilderImpl}
- * for the conditional wiring.
+ * Although Android API 34+ exposes {@code DnsOptions.StaleDnsOptions} in
+ * {@code DnsResolver}, OkHttp's {@code Dns.SYSTEM} uses
+ * {@code InetAddress.getAllByName} which does not opt into that mechanism.
+ * This class is therefore used on all API levels.
  * <p>
  * Instances of this class are thread-safe and designed to be shared across
  * multiple OkHttpClient instances so that the cache persists even when the

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/ComponentsImpl.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/ComponentsImpl.java
@@ -25,8 +25,6 @@ import com.launchdarkly.sdk.internal.events.DefaultEventSender;
 import com.launchdarkly.sdk.internal.events.Event;
 import com.launchdarkly.sdk.internal.events.EventsConfiguration;
 
-import android.os.Build;
-
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -336,11 +334,6 @@ abstract class ComponentsImpl {
                 new ConnectionPool(1, 5, TimeUnit.MINUTES);
 
         private Dns getOrCreateDns(LDLogger logger) {
-            // API 34+ has native stale-DNS support in the platform resolver,
-            // so we only need our CachingDns fallback on older versions.
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                return Dns.SYSTEM;
-            }
             CachingDns dns = sharedDns;
             if (dns == null) {
                 synchronized (this) {

--- a/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/CachingDnsTest.java
+++ b/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/CachingDnsTest.java
@@ -1,0 +1,134 @@
+package com.launchdarkly.sdk.android;
+
+import static org.junit.Assert.assertEquals;
+
+import com.launchdarkly.logging.LDLogger;
+
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import okhttp3.Dns;
+
+public class CachingDnsTest {
+
+    private static final LDLogger logger = LDLogger.none();
+
+    private static Dns counting(List<InetAddress> result, AtomicInteger counter) {
+        return hostname -> {
+            counter.incrementAndGet();
+            return result;
+        };
+    }
+
+    private static Dns failing() {
+        return hostname -> {
+            throw new UnknownHostException("simulated DNS failure for " + hostname);
+        };
+    }
+
+    @Test
+    public void returnsFreshResultFromDelegate() throws Exception {
+        InetAddress addr = InetAddress.getByName("127.0.0.1");
+        List<InetAddress> expected = Collections.singletonList(addr);
+        AtomicInteger lookups = new AtomicInteger();
+        CachingDns dns = new CachingDns(counting(expected, lookups), 60_000, logger);
+
+        List<InetAddress> result = dns.lookup("example.com");
+        assertEquals(expected, result);
+        assertEquals(1, lookups.get());
+    }
+
+    @Test
+    public void returnsCachedResultWithinTtl() throws Exception {
+        InetAddress addr = InetAddress.getByName("127.0.0.1");
+        List<InetAddress> expected = Collections.singletonList(addr);
+        AtomicInteger lookups = new AtomicInteger();
+        CachingDns dns = new CachingDns(counting(expected, lookups), 60_000, logger);
+
+        dns.lookup("example.com");
+        List<InetAddress> result = dns.lookup("example.com");
+
+        assertEquals(expected, result);
+        assertEquals(1, lookups.get());
+    }
+
+    @Test
+    public void refreshesAfterTtlExpires() throws Exception {
+        InetAddress addr = InetAddress.getByName("127.0.0.1");
+        List<InetAddress> expected = Collections.singletonList(addr);
+        AtomicInteger lookups = new AtomicInteger();
+        CachingDns dns = new CachingDns(counting(expected, lookups), 0, logger);
+
+        dns.lookup("example.com");
+        dns.lookup("example.com");
+
+        assertEquals(2, lookups.get());
+    }
+
+    @Test
+    public void fallsBackToStaleCacheOnFailure() throws Exception {
+        InetAddress addr = InetAddress.getByName("127.0.0.1");
+        List<InetAddress> cached = Collections.singletonList(addr);
+
+        AtomicInteger lookups = new AtomicInteger();
+        Dns flaky = hostname -> {
+            if (lookups.incrementAndGet() == 1) {
+                return cached;
+            }
+            throw new UnknownHostException("simulated failure");
+        };
+
+        CachingDns dns = new CachingDns(flaky, 0, logger);
+        dns.lookup("example.com");
+
+        List<InetAddress> result = dns.lookup("example.com");
+        assertEquals(cached, result);
+    }
+
+    @Test(expected = UnknownHostException.class)
+    public void throwsWhenDelegateFailsAndNoCacheExists() throws Exception {
+        CachingDns dns = new CachingDns(failing(), 60_000, logger);
+        dns.lookup("no-such-host.invalid");
+    }
+
+    @Test
+    public void cachesPerHostname() throws Exception {
+        InetAddress addr1 = InetAddress.getByName("10.0.0.1");
+        InetAddress addr2 = InetAddress.getByName("10.0.0.2");
+        List<InetAddress> list1 = Collections.singletonList(addr1);
+        List<InetAddress> list2 = Collections.singletonList(addr2);
+
+        AtomicInteger lookups = new AtomicInteger();
+        Dns delegate = hostname -> {
+            lookups.incrementAndGet();
+            return hostname.equals("a.example.com") ? list1 : list2;
+        };
+        CachingDns dns = new CachingDns(delegate, 60_000, logger);
+
+        assertEquals(list1, dns.lookup("a.example.com"));
+        assertEquals(list2, dns.lookup("b.example.com"));
+        assertEquals(2, lookups.get());
+
+        assertEquals(list1, dns.lookup("a.example.com"));
+        assertEquals(list2, dns.lookup("b.example.com"));
+        assertEquals(2, lookups.get());
+    }
+
+    @Test
+    public void cacheEntryRecordsExpiration() {
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        List<InetAddress> addrs = Collections.singletonList(loopback);
+
+        long now = System.currentTimeMillis();
+        CachingDns.CacheEntry entry = new CachingDns.CacheEntry(addrs, now + 5000);
+
+        assertEquals(false, entry.isExpired(now));
+        assertEquals(true, entry.isExpired(now + 5000));
+        assertEquals(true, entry.isExpired(now + 6000));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `CachingDns`, a thread-safe OkHttp `Dns` wrapper that caches successful lookups (10-min TTL) and returns stale cached addresses when a fresh resolution fails — preventing `UnknownHostException` from killing the stream during network transitions
- Share a `ConnectionPool` and the DNS resolver across `StreamingDataSource` restarts (context switches, foreground/background toggles, network changes) via `StreamingDataSourceBuilderImpl`, so cached state survives data source recreation
- Explicitly set `retryOnConnectionFailure(true)` on the streaming OkHttpClient on all API levels

## Background

We observed a high percentage of DNS failures in streaming connections. The root cause is that `StreamingDataSource` creates a new `OkHttpClient` on every `start()` call, and `ConnectivityManager` restarts the data source on every network change — exactly when DNS is most fragile. OkHttp uses `Dns.SYSTEM` (`InetAddress.getAllByName`) with no caching, and Android's system DNS cache has very short TTLs (sometimes ~2 seconds) that get cleared on network transitions.

This pattern of application-level DNS caching with stale fallback is well-established: Alibaba's HTTPDNS SDK, gRPC-Java's `DnsNameResolver`, and Square's own `DnsOverHttps` module all implement similar approaches. Google validated the pattern by adding `DnsOptions.StaleDnsOptions` to the Android framework in API 34.

## Test plan

- [x] Unit tests for `CachingDns`: fresh resolution, cache hits within TTL, TTL expiry refresh, stale fallback on failure, cold failure propagation, per-hostname isolation, expiration boundary
- [x] Existing `StreamingDataSourceTest` passes (builder creates data source with new constructor args transparently)
- [ ] Verify via logs that `CachingDns` warns on stale fallback and that stream reconnects succeed during network changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches streaming network connection setup and DNS resolution behavior; incorrect caching/pooling could cause connectivity regressions or use stale IPs longer than intended.
> 
> **Overview**
> Adds `CachingDns`, an OkHttp `Dns` wrapper that caches successful lookups with a TTL and falls back to stale cached addresses when fresh resolution fails, reducing `UnknownHostException` disruptions during mobile network transitions.
> 
> Updates streaming to **reuse** a shared DNS resolver and `ConnectionPool` across `StreamingDataSource` restarts, and wires these into the EventSource OkHttp client configuration (including enabling `retryOnConnectionFailure(true)`). Includes unit tests covering cache hit/expiry behavior, stale fallback, per-host caching, and eviction behavior when exceeding `MAX_ENTRIES`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a6a23e13e6c627d45033ab8dd0f2086b6b1770a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->