### PR TITLE
chore: FDv2 Cache Initializer: Guaranteed cache load before the startup timeout begins

### DIFF
--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/FDv2CacheInitializer.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/FDv2CacheInitializer.java
@@ -100,6 +100,11 @@ final class FDv2CacheInitializer implements Initializer {
     }
 
     @Override
+    public boolean isRequiredBeforeStartup() {
+        return true;
+    }
+
+    @Override
     public void close() {
         // No-op: the cache read runs synchronously in run(), so there is nothing to cancel.
     }

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/FDv2DataSource.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/FDv2DataSource.java
@@ -69,7 +69,7 @@ final class FDv2DataSource implements DataSource {
      */
     FDv2DataSource(
             @NonNull LDContext evaluationContext,
-            @NonNull List<DataSourceFactory<Initializer>> initializers,
+            @NonNull List<Initializer> initializers,
             @NonNull List<DataSourceFactory<Synchronizer>> synchronizers,
             @Nullable DataSourceFactory<Synchronizer> fdv1FallbackSynchronizer,
             @NonNull DataSourceUpdateSinkV2 dataSourceUpdateSink,
@@ -84,7 +84,7 @@ final class FDv2DataSource implements DataSource {
 
     /**
      * @param evaluationContext          the context to evaluate flags for
-     * @param initializers               factories for one-shot initializers, tried in order
+     * @param initializers               pre-built initializers, tried in order
      * @param synchronizers              factories for recurring synchronizers, tried in order
      * @param fdv1FallbackSynchronizer   factory for the FDv1 fallback synchronizer, or null if none;
      *                                   appended after the regular synchronizers in a blocked state
@@ -101,7 +101,7 @@ final class FDv2DataSource implements DataSource {
      */
     FDv2DataSource(
             @NonNull LDContext evaluationContext,
-            @NonNull List<DataSourceFactory<Initializer>> initializers,
+            @NonNull List<Initializer> initializers,
             @NonNull List<DataSourceFactory<Synchronizer>> synchronizers,
             @Nullable DataSourceFactory<Synchronizer> fdv1FallbackSynchronizer,
             @NonNull DataSourceUpdateSinkV2 dataSourceUpdateSink,
@@ -155,6 +155,12 @@ final class FDv2DataSource implements DataSource {
         // race with a concurrent stop() and could undo it, causing a spurious OFF/exhaustion report.
         LDContext context = evaluationContext;
 
+        // Eager pass: run pre-startup initializers synchronously on the calling thread.
+        // This ensures cached data is available before the startup timeout begins,
+        // matching FDv1 behavior where cache was loaded in ContextDataManager's constructor.
+        boolean initializerDataReceived = runInitializers(context, dataSourceUpdateSink, true, false);
+        sourceManager.resetInitializerIndex();
+
         sharedExecutor.execute(() -> {
             try {
                 if (!sourceManager.hasAvailableSources()) {
@@ -164,8 +170,9 @@ final class FDv2DataSource implements DataSource {
                     return; // this will go to the finally block and block until stop sets shutdownCause
                 }
 
+                // Deferred pass: run non-eager initializers on the executor thread.
                 if (sourceManager.hasInitializers()) {
-                    runInitializers(context, dataSourceUpdateSink);
+                    runInitializers(context, dataSourceUpdateSink, false, initializerDataReceived);
                 }
 
                 if (!sourceManager.hasAvailableSynchronizers()) {
@@ -286,12 +293,14 @@ final class FDv2DataSource implements DataSource {
         return !evaluationContext.equals(newEvaluationContext);
     }
 
-    private void runInitializers(
+    private boolean runInitializers(
             @NonNull LDContext context,
-            @NonNull DataSourceUpdateSinkV2 sink
+            @NonNull DataSourceUpdateSinkV2 sink,
+            boolean isRequiredBeforeStartup,
+            boolean previousDataReceived
     ) {
-        boolean anyDataReceived = false;
-        Initializer initializer = sourceManager.getNextInitializerAndSetActive();
+        boolean anyDataReceived = previousDataReceived;
+        Initializer initializer = sourceManager.getNextInitializerAndSetActive(isRequiredBeforeStartup);
         while (initializer != null) {
             try {
                 FDv2SourceResult result = initializer.run().get();
@@ -313,7 +322,7 @@ final class FDv2DataSource implements DataSource {
                         sink.setStatus(DataSourceState.VALID, null);
                         tryCompleteStart(true, null);
                     }
-                    return;
+                    return anyDataReceived;
                 }
 
                 switch (result.getResultType()) {
@@ -327,7 +336,7 @@ final class FDv2DataSource implements DataSource {
                             if (!changeSet.getSelector().isEmpty()) {
                                 sink.setStatus(DataSourceState.VALID, null);
                                 tryCompleteStart(true, null);
-                                return;
+                                return anyDataReceived;
                             }
                             // Empty selector: partial data received, keep trying remaining initializers.
                         }
@@ -358,18 +367,19 @@ final class FDv2DataSource implements DataSource {
             } catch (InterruptedException e) {
                 logger.warn("Initializer interrupted: {}", e.toString());
                 sink.setStatus(DataSourceState.INTERRUPTED, e);
-                return;
+                return anyDataReceived;
             }
-            initializer = sourceManager.getNextInitializerAndSetActive();
+            initializer = sourceManager.getNextInitializerAndSetActive(isRequiredBeforeStartup);
         }
-        // All initializers exhausted. If data was received and no synchronizers will follow,
-        // consider initialization successful. When synchronizers are available, defer init
-        // completion to the synchronizer loop — the synchronizer is the authority on whether
-        // the SDK has a verified, up-to-date payload.
+        // All matching initializers exhausted. If data was received and no synchronizers will
+        // follow, consider initialization successful. When synchronizers are available, defer
+        // init completion to the synchronizer loop — the synchronizer is the authority on
+        // whether the SDK has a verified, up-to-date payload.
         if (anyDataReceived && !sourceManager.hasAvailableSynchronizers()) {
             sink.setStatus(DataSourceState.VALID, null);
             tryCompleteStart(true, null);
         }
+        return anyDataReceived;
     }
 
     private List<FDv2DataSourceConditions.Condition> getConditions(int synchronizerCount, boolean isPrime) {

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/FDv2DataSourceBuilder.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/FDv2DataSourceBuilder.java
@@ -126,15 +126,15 @@ class FDv2DataSourceBuilder implements ComponentConfigurer<DataSource>, Closeabl
                     "FDv2DataSource requires a DataSourceUpdateSinkV2 implementation");
         }
 
-        List<FDv2DataSource.DataSourceFactory<Initializer>> initFactories =
-                includeInitializers ? resolved.getInitializerFactories() : Collections.<FDv2DataSource.DataSourceFactory<Initializer>>emptyList();
+        List<Initializer> initializers =
+                includeInitializers ? resolved.getInitializers() : Collections.<Initializer>emptyList();
 
         // Reset includeInitializers to default after each build to prevent stale state.
         includeInitializers = true;
 
         return new FDv2DataSource(
                 clientContext.getEvaluationContext(),
-                initFactories,
+                initializers,
                 resolved.getSynchronizerFactories(),
                 resolved.getFdv1FallbackSynchronizerFactory(),
                 (DataSourceUpdateSinkV2) baseSink,
@@ -174,7 +174,7 @@ class FDv2DataSourceBuilder implements ComponentConfigurer<DataSource>, Closeabl
             ModeDefinition def, DataSourceBuildInputs inputs,
             @Nullable PersistentDataStoreWrapper.ReadOnlyPerEnvironmentData envData
     ) {
-        List<FDv2DataSource.DataSourceFactory<Initializer>> initFactories = new ArrayList<>();
+        List<Initializer> initializers = new ArrayList<>();
         for (DataSourceBuilder<Initializer> builder : def.getInitializers()) {
             // The cache initializer's dependency (ReadOnlyPerEnvironmentData) is only
             // available at build time, not when the static mode table is constructed,
@@ -185,7 +185,10 @@ class FDv2DataSourceBuilder implements ComponentConfigurer<DataSource>, Closeabl
             } else {
                 effective = builder;
             }
-            initFactories.add(() -> effective.build(inputs));
+            Initializer init = effective.build(inputs);
+            if (init != null) {
+                initializers.add(init);
+            }
         }
         List<FDv2DataSource.DataSourceFactory<Synchronizer>> syncFactories = new ArrayList<>();
         for (DataSourceBuilder<Synchronizer> builder : def.getSynchronizers()) {
@@ -194,6 +197,6 @@ class FDv2DataSourceBuilder implements ComponentConfigurer<DataSource>, Closeabl
         DataSourceBuilder<Synchronizer> fdv1FallbackSynchronizer = def.getFdv1FallbackSynchronizer();
         FDv2DataSource.DataSourceFactory<Synchronizer> fdv1Factory =
                 fdv1FallbackSynchronizer != null ? () -> fdv1FallbackSynchronizer.build(inputs) : null;
-        return new ResolvedModeDefinition(initFactories, syncFactories, fdv1Factory);
+        return new ResolvedModeDefinition(initializers, syncFactories, fdv1Factory);
     }
 }

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/ResolvedModeDefinition.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/ResolvedModeDefinition.java
@@ -10,10 +10,13 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * A fully resolved mode definition containing zero-arg factories for initializers
- * and synchronizers. This is the result of resolving a {@link ModeDefinition}'s
+ * A fully resolved mode definition containing pre-built initializers and zero-arg
+ * factories for synchronizers. This is the result of resolving a {@link ModeDefinition}'s
  * {@link com.launchdarkly.sdk.android.subsystems.DataSourceBuilder} entries against
  * a {@link com.launchdarkly.sdk.android.subsystems.DataSourceBuildInputs}.
+ * <p>
+ * Initializers are built eagerly so that {@link FDv2DataSource} can run pre-startup
+ * initializers synchronously before dispatching to the executor.
  * <p>
  * Instances are immutable and created by {@code FDv2DataSourceBuilder} at build time.
  * <p>
@@ -23,23 +26,23 @@ import java.util.List;
  */
 final class ResolvedModeDefinition {
 
-    private final List<FDv2DataSource.DataSourceFactory<Initializer>> initializerFactories;
+    private final List<Initializer> initializers;
     private final List<FDv2DataSource.DataSourceFactory<Synchronizer>> synchronizerFactories;
     private final FDv2DataSource.DataSourceFactory<Synchronizer> fdv1FallbackSynchronizerFactory;
 
     ResolvedModeDefinition(
-            @NonNull List<FDv2DataSource.DataSourceFactory<Initializer>> initializerFactories,
+            @NonNull List<Initializer> initializers,
             @NonNull List<FDv2DataSource.DataSourceFactory<Synchronizer>> synchronizerFactories,
             @Nullable FDv2DataSource.DataSourceFactory<Synchronizer> fdv1FallbackSynchronizerFactory
     ) {
-        this.initializerFactories = Collections.unmodifiableList(initializerFactories);
+        this.initializers = Collections.unmodifiableList(initializers);
         this.synchronizerFactories = Collections.unmodifiableList(synchronizerFactories);
         this.fdv1FallbackSynchronizerFactory = fdv1FallbackSynchronizerFactory;
     }
 
     @NonNull
-    List<FDv2DataSource.DataSourceFactory<Initializer>> getInitializerFactories() {
-        return initializerFactories;
+    List<Initializer> getInitializers() {
+        return initializers;
     }
 
     @NonNull

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/SourceManager.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/SourceManager.java
@@ -19,7 +19,7 @@ import java.util.List;
 final class SourceManager implements Closeable {
 
     private final List<SynchronizerFactoryWithState> synchronizerFactories;
-    private final List<FDv2DataSource.DataSourceFactory<Initializer>> initializers;
+    private final List<Initializer> initializers;
 
     private final Object activeSourceLock = new Object();
     private Closeable activeSource;
@@ -33,7 +33,7 @@ final class SourceManager implements Closeable {
 
     SourceManager(
             @NonNull List<SynchronizerFactoryWithState> synchronizerFactories,
-            @NonNull List<FDv2DataSource.DataSourceFactory<Initializer>> initializers
+            @NonNull List<Initializer> initializers
     ) {
         this.synchronizerFactories = synchronizerFactories;
         this.initializers = initializers;
@@ -143,14 +143,6 @@ final class SourceManager implements Closeable {
         return getAvailableSynchronizerCount() > 0;
     }
 
-    private FDv2DataSource.DataSourceFactory<Initializer> getNextInitializer() {
-        initializerIndex++;
-        if (initializerIndex >= initializers.size()) {
-            return null;
-        }
-        return initializers.get(initializerIndex);
-    }
-
     /** Block the current synchronizer so it will not be returned again (e.g. after TERMINAL_ERROR). */
     void blockCurrentSynchronizer() {
         synchronized (activeSourceLock) {
@@ -167,29 +159,43 @@ final class SourceManager implements Closeable {
     }
 
     /**
-     * Get the next initializer, build it, set it as active (closing any previous active source),
-     * and return it. Returns null if shutdown or no more initializers.
-     * Skips initializers whose factory returns null from build().
+     * Get the next pre-built initializer whose {@link Initializer#isRequiredBeforeStartup()}
+     * matches the given value, set it as active (closing any previous active source),
+     * and return it. Returns null if shutdown or no more matching initializers.
+     * <p>
+     * Call with {@code true} for the eager pass (pre-startup), then
+     * {@link #resetInitializerIndex()}, then call with {@code false} for the deferred pass.
+     *
+     * @param isRequiredBeforeStartup filter value to match against each initializer
      */
-    Initializer getNextInitializerAndSetActive() {
+    Initializer getNextInitializerAndSetActive(boolean isRequiredBeforeStartup) {
         synchronized (activeSourceLock) {
             if (isShutdown) {
                 return null;
             }
-            while (true) {
-                FDv2DataSource.DataSourceFactory<Initializer> factory = getNextInitializer();
-                if (factory == null) {
-                    return null;
-                }
-                Initializer initializer = factory.build();
-                if (initializer != null) {
+            while (initializerIndex + 1 < initializers.size()) {
+                initializerIndex++;
+                Initializer init = initializers.get(initializerIndex);
+                if (init.isRequiredBeforeStartup() == isRequiredBeforeStartup) {
                     if (activeSource != null) {
                         safeClose(activeSource);
                     }
-                    activeSource = initializer;
-                    return initializer;
+                    activeSource = init;
+                    return init;
                 }
             }
+            return null;
+        }
+    }
+
+    /**
+     * Reset the initializer index to -1 so the next call to
+     * {@link #getNextInitializerAndSetActive(boolean)} re-scans from the beginning.
+     * Used between the eager and deferred initializer passes.
+     */
+    void resetInitializerIndex() {
+        synchronized (activeSourceLock) {
+            initializerIndex = -1;
         }
     }
 

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/subsystems/Initializer.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/subsystems/Initializer.java
@@ -26,4 +26,18 @@ public interface Initializer extends Closeable {
      * @return a Future that completes with the result
      */
     Future<FDv2SourceResult> run();
+
+    /**
+     * Whether this initializer must run before the startup timeout begins ticking.
+     * <p>
+     * Eager initializers run synchronously on the calling thread during
+     * {@code FDv2DataSource.start()}, before work is dispatched to the executor.
+     * This guarantees their data is available even with a timeout of zero,
+     * matching the FDv1 behavior where cached data was loaded in the constructor.
+     *
+     * @return {@code true} if this initializer must complete before the timeout starts
+     */
+    default boolean isRequiredBeforeStartup() {
+        return false;
+    }
 }

--- a/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/FDv2CacheInitializerTest.java
+++ b/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/FDv2CacheInitializerTest.java
@@ -189,6 +189,15 @@ public class FDv2CacheInitializerTest {
         initializer.close();
     }
 
+    // ---- isRequiredBeforeStartup ----
+
+    @Test
+    public void isRequiredBeforeStartup_returnsTrue() {
+        FDv2CacheInitializer initializer = new FDv2CacheInitializer(
+                null, CONTEXT, LDLogger.none());
+        assertTrue(initializer.isRequiredBeforeStartup());
+    }
+
     // ---- empty cache (no flags stored, but store exists) ----
 
     @Test

--- a/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/FDv2DataSourceTest.java
+++ b/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/FDv2DataSourceTest.java
@@ -76,7 +76,7 @@ public class FDv2DataSourceTest {
 
     private FDv2DataSource buildDataSource(
             MockComponents.MockDataSourceUpdateSink sink,
-            List<FDv2DataSource.DataSourceFactory<Initializer>> initializers,
+            List<Initializer> initializers,
             List<FDv2DataSource.DataSourceFactory<Synchronizer>> synchronizers) {
         return new FDv2DataSource(
                 CONTEXT,
@@ -90,7 +90,7 @@ public class FDv2DataSourceTest {
 
     private FDv2DataSource buildDataSource(
             MockComponents.MockDataSourceUpdateSink sink,
-            List<FDv2DataSource.DataSourceFactory<Initializer>> initializers,
+            List<Initializer> initializers,
             List<FDv2DataSource.DataSourceFactory<Synchronizer>> synchronizers,
             long fallbackTimeoutSeconds,
             long recoveryTimeoutSeconds) {
@@ -301,7 +301,7 @@ public class FDv2DataSourceTest {
         items.put(flag.getKey(), flag);
 
         FDv2DataSource dataSource = buildDataSource(sink,
-                Collections.singletonList(() -> new MockInitializer(FDv2SourceResult.changeSet(makeFullChangeSet(items), false))),
+                Collections.singletonList(new MockInitializer(FDv2SourceResult.changeSet(makeFullChangeSet(items), false))),
                 Collections.emptyList());
 
         AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
@@ -319,11 +319,14 @@ public class FDv2DataSourceTest {
         AtomicBoolean secondCalled = new AtomicBoolean(false);
 
         FDv2DataSource dataSource = buildDataSource(sink,
-                Arrays.asList(
-                        () -> new MockInitializer(new RuntimeException("first fails")),
-                        () -> {
-                            secondCalled.set(true);
-                            return new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false));
+                Arrays.<Initializer>asList(
+                        new MockInitializer(new RuntimeException("first fails")),
+                        new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false)) {
+                            @Override
+                            public LDAwaitFuture<FDv2SourceResult> run() {
+                                secondCalled.set(true);
+                                return super.run();
+                            }
                         }),
                 Collections.emptyList());
 
@@ -341,11 +344,14 @@ public class FDv2DataSourceTest {
         AtomicBoolean secondCalled = new AtomicBoolean(false);
 
         FDv2DataSource dataSource = buildDataSource(sink,
-                Arrays.asList(
-                        () -> new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false)),
-                        () -> {
-                            secondCalled.set(true);
-                            return new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false));
+                Arrays.<Initializer>asList(
+                        new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false)),
+                        new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false)) {
+                            @Override
+                            public LDAwaitFuture<FDv2SourceResult> run() {
+                                secondCalled.set(true);
+                                return super.run();
+                            }
                         }),
                 Collections.emptyList());
 
@@ -364,8 +370,8 @@ public class FDv2DataSourceTest {
 
         FDv2DataSource dataSource = buildDataSource(sink,
                 Arrays.asList(
-                        () -> new MockInitializer(new RuntimeException("first fails")),
-                        () -> new MockInitializer(new RuntimeException("second fails"))),
+                        new MockInitializer(new RuntimeException("first fails")),
+                        new MockInitializer(new RuntimeException("second fails"))),
                 Collections.singletonList(() -> {
                     syncCalled.set(true);
                     return new MockSynchronizer(FDv2SourceResult.changeSet(makeChangeSet(false), false));
@@ -385,7 +391,7 @@ public class FDv2DataSourceTest {
 
         FDv2DataSource dataSource = buildDataSource(sink,
                 Collections.singletonList(
-                        () -> new MockInitializer(FDv2SourceResult.status(FDv2SourceResult.Status.terminalError(new RuntimeException("fail")), false))),
+                        new MockInitializer(FDv2SourceResult.status(FDv2SourceResult.Status.terminalError(new RuntimeException("fail")), false))),
                 Collections.emptyList());
 
         AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
@@ -401,8 +407,8 @@ public class FDv2DataSourceTest {
 
         FDv2DataSource dataSource = buildDataSource(sink,
                 Arrays.asList(
-                        () -> new MockInitializer(FDv2SourceResult.status(FDv2SourceResult.Status.terminalError(new RuntimeException("first fails")), false)),
-                        () -> new MockInitializer(FDv2SourceResult.changeSet(makeFullChangeSet(items), false))),
+                        new MockInitializer(FDv2SourceResult.status(FDv2SourceResult.Status.terminalError(new RuntimeException("first fails")), false)),
+                        new MockInitializer(FDv2SourceResult.changeSet(makeFullChangeSet(items), false))),
                 Collections.emptyList());
 
         AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
@@ -418,7 +424,7 @@ public class FDv2DataSourceTest {
         MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
 
         FDv2DataSource dataSource = buildDataSource(sink,
-                Collections.singletonList(() -> new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false))),
+                Collections.singletonList(new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false))),
                 Collections.emptyList());
 
         AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
@@ -469,7 +475,7 @@ public class FDv2DataSourceTest {
         MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
 
         FDv2DataSource dataSource = buildDataSource(sink,
-                Collections.singletonList(() -> new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(false), false))),
+                Collections.singletonList(new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(false), false))),
                 Collections.singletonList(() -> new MockQueuedSynchronizer(
                         FDv2SourceResult.changeSet(makeChangeSet(false), false))));
 
@@ -727,7 +733,7 @@ public class FDv2DataSourceTest {
         MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
 
         FDv2DataSource dataSource = buildDataSource(sink,
-                Collections.singletonList(() -> new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false))),
+                Collections.singletonList(new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false))),
                 Collections.emptyList());
 
         AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
@@ -764,7 +770,7 @@ public class FDv2DataSourceTest {
         MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
 
         FDv2DataSource dataSource = buildDataSource(sink,
-                Collections.singletonList(() -> new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false))),
+                Collections.singletonList(new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false))),
                 Collections.emptyList());
 
         AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
@@ -781,7 +787,7 @@ public class FDv2DataSourceTest {
         LDAwaitFuture<FDv2SourceResult> slowFuture = new LDAwaitFuture<>();
 
         FDv2DataSource dataSource = buildDataSource(sink,
-                Collections.singletonList(() -> new MockInitializer(slowFuture)),
+                Collections.singletonList(new MockInitializer(slowFuture)),
                 Collections.emptyList());
 
         AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
@@ -904,10 +910,14 @@ public class FDv2DataSourceTest {
         AtomicInteger runCount = new AtomicInteger(0);
 
         FDv2DataSource dataSource = buildDataSource(sink,
-                Collections.singletonList(() -> {
-                    runCount.incrementAndGet();
-                    return new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false));
-                }),
+                Collections.<Initializer>singletonList(
+                        new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false)) {
+                            @Override
+                            public LDAwaitFuture<FDv2SourceResult> run() {
+                                runCount.incrementAndGet();
+                                return super.run();
+                            }
+                        }),
                 Collections.emptyList());
 
         AwaitableCallback<Boolean> cb1 = new AwaitableCallback<>();
@@ -1018,9 +1028,15 @@ public class FDv2DataSourceTest {
         AtomicBoolean firstCalled = new AtomicBoolean(false);
 
         FDv2DataSource dataSource = buildDataSource(sink,
-                Arrays.asList(
-                        () -> { firstCalled.set(true); return new MockInitializer(new RuntimeException("execution exception")); },
-                        () -> new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false))),
+                Arrays.<Initializer>asList(
+                        new MockInitializer(new RuntimeException("execution exception")) {
+                            @Override
+                            public LDAwaitFuture<FDv2SourceResult> run() {
+                                firstCalled.set(true);
+                                return super.run();
+                            }
+                        },
+                        new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false))),
                 Collections.emptyList());
 
         AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
@@ -1036,9 +1052,15 @@ public class FDv2DataSourceTest {
         AtomicBoolean firstCalled = new AtomicBoolean(false);
 
         FDv2DataSource dataSource = buildDataSource(sink,
-                Arrays.asList(
-                        () -> { firstCalled.set(true); return new MockInitializer(new InterruptedException("interrupted")); },
-                        () -> new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false))),
+                Arrays.<Initializer>asList(
+                        new MockInitializer(new InterruptedException("interrupted")) {
+                            @Override
+                            public LDAwaitFuture<FDv2SourceResult> run() {
+                                firstCalled.set(true);
+                                return super.run();
+                            }
+                        },
+                        new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false))),
                 Collections.emptyList());
 
         AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
@@ -1145,7 +1167,7 @@ public class FDv2DataSourceTest {
         LDAwaitFuture<FDv2SourceResult> slowFuture = new LDAwaitFuture<>();
 
         FDv2DataSource dataSource = buildDataSource(sink,
-                Collections.singletonList(() -> new MockInitializer(slowFuture) {
+                Collections.singletonList(new MockInitializer(slowFuture) {
                     @Override
                     public LDAwaitFuture<FDv2SourceResult> run() {
                         initializerStarted.countDown();
@@ -1301,11 +1323,14 @@ public class FDv2DataSourceTest {
         BlockingQueue<Boolean> secondCalledQueue = new LinkedBlockingQueue<>();
 
         FDv2DataSource dataSource = buildDataSource(sink,
-                Arrays.asList(
-                        () -> new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false)),
-                        () -> {
-                            secondCalledQueue.offer(true);
-                            return new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(false), false));
+                Arrays.<Initializer>asList(
+                        new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false)),
+                        new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(false), false)) {
+                            @Override
+                            public LDAwaitFuture<FDv2SourceResult> run() {
+                                secondCalledQueue.offer(true);
+                                return super.run();
+                            }
                         }),
                 Collections.emptyList());
 
@@ -1322,7 +1347,7 @@ public class FDv2DataSourceTest {
         MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
 
         FDv2DataSource dataSource = buildDataSource(sink,
-                Collections.singletonList(() -> new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(false), false))),
+                Collections.singletonList(new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(false), false))),
                 Collections.emptyList());
 
         AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
@@ -1413,7 +1438,7 @@ public class FDv2DataSourceTest {
         MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
 
         FDv2DataSource dataSource = buildDataSource(sink,
-                Collections.singletonList(() -> new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(false), false))),
+                Collections.singletonList(new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(false), false))),
                 Collections.emptyList());
 
         AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
@@ -1524,11 +1549,14 @@ public class FDv2DataSourceTest {
 
         FDv2DataSource dataSource = new FDv2DataSource(
                 CONTEXT,
-                Arrays.<FDv2DataSource.DataSourceFactory<Initializer>>asList(
-                        () -> new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(false), true)),
-                        () -> {
-                            secondInitCalled.set(true);
-                            return new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false));
+                Arrays.<Initializer>asList(
+                        new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(false), true)),
+                        new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false)) {
+                            @Override
+                            public LDAwaitFuture<FDv2SourceResult> run() {
+                                secondInitCalled.set(true);
+                                return super.run();
+                            }
                         }),
                 Collections.<FDv2DataSource.DataSourceFactory<Synchronizer>>singletonList(
                         () -> new MockSynchronizer(FDv2SourceResult.changeSet(makeChangeSet(false), false))),
@@ -1559,12 +1587,15 @@ public class FDv2DataSourceTest {
         // The fallback should be honored and remaining initializers skipped.
         FDv2DataSource dataSource = new FDv2DataSource(
                 CONTEXT,
-                Arrays.<FDv2DataSource.DataSourceFactory<Initializer>>asList(
-                        () -> new MockInitializer(FDv2SourceResult.status(
+                Arrays.<Initializer>asList(
+                        new MockInitializer(FDv2SourceResult.status(
                                 FDv2SourceResult.Status.terminalError(new RuntimeException("fail")), true)),
-                        () -> {
-                            secondInitCalled.set(true);
-                            return new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false));
+                        new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false)) {
+                            @Override
+                            public LDAwaitFuture<FDv2SourceResult> run() {
+                                secondInitCalled.set(true);
+                                return super.run();
+                            }
                         }),
                 Collections.<FDv2DataSource.DataSourceFactory<Synchronizer>>singletonList(
                         () -> new MockSynchronizer(FDv2SourceResult.changeSet(makeChangeSet(false), false))),
@@ -1596,8 +1627,8 @@ public class FDv2DataSourceTest {
         // complete initialization immediately.
         FDv2DataSource dataSource = new FDv2DataSource(
                 CONTEXT,
-                Collections.<FDv2DataSource.DataSourceFactory<Initializer>>singletonList(
-                        () -> new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), true))),
+                Collections.<Initializer>singletonList(
+                        new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), true))),
                 Collections.<FDv2DataSource.DataSourceFactory<Synchronizer>>singletonList(
                         () -> new MockSynchronizer(FDv2SourceResult.changeSet(makeChangeSet(true), false))),
                 () -> fdv1Sync,
@@ -1626,7 +1657,7 @@ public class FDv2DataSourceTest {
 
         FDv2DataSource dataSource = new FDv2DataSource(
                 CONTEXT,
-                Collections.<FDv2DataSource.DataSourceFactory<Initializer>>emptyList(),
+                Collections.<Initializer>emptyList(),
                 Collections.<FDv2DataSource.DataSourceFactory<Synchronizer>>singletonList(() -> fdv2Sync),
                 () -> fdv1Sync,
                 sink,
@@ -1660,7 +1691,7 @@ public class FDv2DataSourceTest {
 
         FDv2DataSource dataSource = new FDv2DataSource(
                 CONTEXT,
-                Collections.<FDv2DataSource.DataSourceFactory<Initializer>>emptyList(),
+                Collections.<Initializer>emptyList(),
                 Collections.<FDv2DataSource.DataSourceFactory<Synchronizer>>singletonList(() -> fdv2Sync),
                 () -> fdv1Sync,
                 sink,
@@ -1692,7 +1723,7 @@ public class FDv2DataSourceTest {
 
         FDv2DataSource dataSource = new FDv2DataSource(
                 CONTEXT,
-                Collections.<FDv2DataSource.DataSourceFactory<Initializer>>emptyList(),
+                Collections.<Initializer>emptyList(),
                 Collections.<FDv2DataSource.DataSourceFactory<Synchronizer>>singletonList(() -> fdv2Sync),
                 () -> {
                     fdv1BuildCount.incrementAndGet();
@@ -1721,7 +1752,7 @@ public class FDv2DataSourceTest {
                 FDv2SourceResult.changeSet(makeChangeSet(true), true));
 
         FDv2DataSource dataSource = buildDataSource(sink,
-                Collections.<FDv2DataSource.DataSourceFactory<Initializer>>emptyList(),
+                Collections.<Initializer>emptyList(),
                 Collections.<FDv2DataSource.DataSourceFactory<Synchronizer>>singletonList(() -> fdv2Sync));
 
         AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
@@ -1749,5 +1780,178 @@ public class FDv2DataSourceTest {
                 Collections.emptyList(),
                 Collections.emptyList());
         assertTrue(dataSource.needsRefresh(false, LDContext.create("other-context")));
+    }
+
+    // ============================================================================
+    // Eager (Pre-Startup) Initializers
+    // ============================================================================
+
+    @Test
+    public void eagerInitializerRunsBeforeExecutorDispatch() throws Exception {
+        MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
+        AtomicReference<String> eagerThread = new AtomicReference<>();
+        AtomicReference<String> callingThread = new AtomicReference<>();
+
+        Initializer eagerInit = new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(false), false)) {
+            @Override
+            public boolean isRequiredBeforeStartup() {
+                return true;
+            }
+
+            @Override
+            public LDAwaitFuture<FDv2SourceResult> run() {
+                eagerThread.set(Thread.currentThread().getName());
+                return super.run();
+            }
+        };
+
+        FDv2DataSource dataSource = buildDataSource(sink,
+                Collections.<Initializer>singletonList(eagerInit),
+                Collections.singletonList(() -> new MockQueuedSynchronizer(
+                        FDv2SourceResult.changeSet(makeChangeSet(true), false))));
+
+        callingThread.set(Thread.currentThread().getName());
+        AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
+        assertTrue(startCallback.await(AWAIT_TIMEOUT_SECONDS * 1000));
+
+        assertEquals("Eager initializer must run on the calling thread",
+                callingThread.get(), eagerThread.get());
+        stopDataSource(dataSource);
+    }
+
+    @Test
+    public void deferredInitializerRunsOnExecutorThread() throws Exception {
+        MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
+        AtomicReference<String> deferredThread = new AtomicReference<>();
+        CountDownLatch deferredRan = new CountDownLatch(1);
+
+        Initializer deferredInit = new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false)) {
+            @Override
+            public boolean isRequiredBeforeStartup() {
+                return false;
+            }
+
+            @Override
+            public LDAwaitFuture<FDv2SourceResult> run() {
+                deferredThread.set(Thread.currentThread().getName());
+                deferredRan.countDown();
+                return super.run();
+            }
+        };
+
+        FDv2DataSource dataSource = buildDataSource(sink,
+                Collections.<Initializer>singletonList(deferredInit),
+                Collections.emptyList());
+
+        String callingThread = Thread.currentThread().getName();
+        AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
+        assertTrue(startCallback.await(AWAIT_TIMEOUT_SECONDS * 1000));
+        assertTrue(deferredRan.await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+
+        assertFalse("Deferred initializer must NOT run on the calling thread",
+                callingThread.equals(deferredThread.get()));
+    }
+
+    @Test
+    public void eagerAndDeferredInitializersBothRun() throws Exception {
+        MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
+        AtomicBoolean eagerRan = new AtomicBoolean(false);
+        CountDownLatch deferredRan = new CountDownLatch(1);
+
+        Initializer eagerInit = new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(false), false)) {
+            @Override
+            public boolean isRequiredBeforeStartup() {
+                return true;
+            }
+
+            @Override
+            public LDAwaitFuture<FDv2SourceResult> run() {
+                eagerRan.set(true);
+                return super.run();
+            }
+        };
+
+        Initializer deferredInit = new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false)) {
+            @Override
+            public boolean isRequiredBeforeStartup() {
+                return false;
+            }
+
+            @Override
+            public LDAwaitFuture<FDv2SourceResult> run() {
+                deferredRan.countDown();
+                return super.run();
+            }
+        };
+
+        FDv2DataSource dataSource = buildDataSource(sink,
+                Arrays.<Initializer>asList(eagerInit, deferredInit),
+                Collections.emptyList());
+
+        AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
+        assertTrue(startCallback.await(AWAIT_TIMEOUT_SECONDS * 1000));
+        assertTrue(deferredRan.await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+
+        assertTrue(eagerRan.get());
+        sink.awaitApplyCount(2, AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertEquals(2, sink.getApplyCount());
+    }
+
+    @Test
+    public void offlineModeWithEagerCacheMissStillInitializes() throws Exception {
+        MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
+
+        Initializer cacheInitializer = new MockInitializer(
+                FDv2SourceResult.changeSet(new ChangeSet<>(
+                        ChangeSetType.None,
+                        com.launchdarkly.sdk.fdv2.Selector.EMPTY,
+                        Collections.<String, DataModel.Flag>emptyMap(),
+                        null,
+                        false), false)) {
+            @Override
+            public boolean isRequiredBeforeStartup() {
+                return true;
+            }
+        };
+
+        FDv2DataSource dataSource = buildDataSource(sink,
+                Collections.<Initializer>singletonList(cacheInitializer),
+                Collections.emptyList());
+
+        AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
+        assertTrue(startCallback.await(AWAIT_TIMEOUT_SECONDS * 1000));
+
+        assertEquals(DataSourceState.VALID, sink.getLastState());
+    }
+
+    @Test
+    public void eagerInitializerDataAvailableWithZeroTimeout() throws Exception {
+        MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
+        DataModel.Flag flag = new FlagBuilder("flag1").version(1).value(LDValue.of(true)).build();
+        Map<String, DataModel.Flag> items = new HashMap<>();
+        items.put(flag.getKey(), flag);
+
+        Initializer eagerInit = new MockInitializer(
+                FDv2SourceResult.changeSet(makeFullChangeSet(items), false)) {
+            @Override
+            public boolean isRequiredBeforeStartup() {
+                return true;
+            }
+        };
+
+        FDv2DataSource dataSource = buildDataSource(sink,
+                Collections.<Initializer>singletonList(eagerInit),
+                Collections.singletonList(() -> new MockQueuedSynchronizer(
+                        FDv2SourceResult.changeSet(makeChangeSet(true), false))));
+
+        AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
+
+        ChangeSet<Map<String, DataModel.Flag>> applied = sink.expectApply();
+        assertNotNull(applied);
+        assertEquals(1, applied.getData().size());
+        assertTrue(applied.getData().containsKey("flag1"));
+
+        assertTrue(startCallback.await(AWAIT_TIMEOUT_SECONDS * 1000));
+        stopDataSource(dataSource);
     }
 }


### PR DESCRIPTION
## Summary

Guarantees that FDv2 cached flag data is available before the startup timeout begins, matching FDv1 behavior where cache was loaded synchronously in `ContextDataManager`'s constructor. Previously, the FDv2 cache initializer ran asynchronously on the executor thread alongside the timeout, meaning clients using `timeout=0` could miss cached data entirely. Now, `FDv2DataSource.start()` executes a two-pass initializer strategy: pre-startup initializers (identified by `isRequiredBeforeStartup()`) run synchronously on the calling thread before the executor is dispatched, while remaining initializers run on the executor as before. Both passes reuse the existing `runInitializers()` method with no changes to result-handling logic.

To support this, initializers are now built eagerly in `FDv2DataSourceBuilder.resolve()` instead of being wrapped in lazy factory lambdas, and `SourceManager` accepts pre-built `List<Initializer>` with a filtered `getNextInitializerAndSetActive(boolean isRequiredBeforeStartup)` method. `FDv2CacheInitializer` overrides the new `isRequiredBeforeStartup()` default method to return `true`. All existing tests are updated for the new signatures, and new tests verify eager execution threading, both passes running, OFFLINE cache miss behavior, and immediate data availability with zero timeout.


**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes FDv2 startup sequencing and threading by running some initializers on the calling thread and eagerly constructing initializer instances, which could affect initialization timing and ordering. Behavior is covered by updated and new tests but touches core data source startup logic.
> 
> **Overview**
> Ensures cached flag data can be applied *before* the FDv2 startup timeout starts by introducing an initializer “eager pass” in `FDv2DataSource.start()` that runs `Initializer`s with `isRequiredBeforeStartup()` synchronously, then runs remaining initializers on the executor as before.
> 
> Refactors initializer wiring to support this: `Initializer` gains `isRequiredBeforeStartup()` (default `false`), `FDv2CacheInitializer` marks itself eager, and the builder/`ResolvedModeDefinition`/`SourceManager` switch from initializer factories to pre-built initializer instances with filtered iteration and an index reset between passes. Tests are updated accordingly and add coverage for eager vs deferred threading and zero-timeout/offline cache-miss scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8caa9fc0851335940529eb7bcb79fca05ac798f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->