### PR TITLE
chore: removing api_key prefix in auth header

### DIFF
--- a/launchdarkly-android-client-sdk/src/androidTest/java/com/launchdarkly/sdk/android/LDClientEventTest.java
+++ b/launchdarkly-android-client-sdk/src/androidTest/java/com/launchdarkly/sdk/android/LDClientEventTest.java
@@ -345,7 +345,7 @@ public class LDClientEventTest {
         RecordedRequest r = server.takeRequest();
         assertEquals("POST", r.getMethod());
         assertEquals("/mobile/events/bulk", r.getPath());
-        assertEquals(LDUtil.AUTH_SCHEME + mobileKey, r.getHeader("Authorization"));
+        assertEquals(mobileKey, r.getHeader("Authorization"));
         String body = r.getBody().readUtf8();
         System.out.println(body);
         LDValue[] events = GsonHelpers.gsonInstance().fromJson(body, LDValue[].class);

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/ComponentsImpl.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/ComponentsImpl.java
@@ -215,7 +215,7 @@ abstract class ComponentsImpl {
             LDLogger logger = clientContext.getBaseLogger();
             // Build the default headers
             Map<String, String> headers = new HashMap<>();
-            headers.put("Authorization", LDUtil.AUTH_SCHEME + clientContext.getMobileKey());
+            headers.put("Authorization", clientContext.getMobileKey());
             headers.put("User-Agent", LDUtil.USER_AGENT_HEADER_VALUE);
             String tagHeader = LDUtil.applicationTagHeader(
                     clientContext.getEnvironmentReporter().getApplicationInfo(),

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDUtil.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDUtil.java
@@ -33,7 +33,6 @@ import okhttp3.Headers;
  * Various utility functions
  */
 public class LDUtil {
-    static final String AUTH_SCHEME = "api_key ";
     static final String USER_AGENT_HEADER_VALUE = LDPackageConsts.SDK_CLIENT_NAME + "/" + BuildConfig.VERSION_NAME;
 
     static <T> Callback<T> noOpCallback() {

--- a/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/HttpConfigurationBuilderTest.java
+++ b/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/HttpConfigurationBuilderTest.java
@@ -19,7 +19,7 @@ public class HttpConfigurationBuilderTest {
 
     private static Map<String, String> buildBasicHeaders() {
         Map<String, String> ret = new HashMap<>();
-        ret.put("Authorization", LDUtil.AUTH_SCHEME + MOBILE_KEY);
+        ret.put("Authorization", MOBILE_KEY);
         ret.put("User-Agent", LDUtil.USER_AGENT_HEADER_VALUE);
         ret.put("X-LaunchDarkly-Tags", "application-id/" + LDPackageConsts.SDK_NAME + " application-name/" + LDPackageConsts.SDK_NAME
                 + " application-version/" + BuildConfig.VERSION_NAME + " application-version-name/" + BuildConfig.VERSION_NAME);

--- a/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/LDConfigTest.java
+++ b/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/LDConfigTest.java
@@ -88,7 +88,7 @@ public class LDConfigTest {
         );
         assertEquals(3, headers.size());
         assertEquals(LDUtil.USER_AGENT_HEADER_VALUE, headers.get("user-agent"));
-        assertEquals("api_key test-key", headers.get("authorization"));
+        assertEquals("test-key", headers.get("authorization"));
     }
 
     @Test
@@ -106,7 +106,7 @@ public class LDConfigTest {
                 null, null, null, null, null, new EnvironmentReporterBuilder().build(), null);
 
         expected.put("User-Agent", LDUtil.USER_AGENT_HEADER_VALUE);
-        expected.put("Authorization", "api_key test-key");
+        expected.put("Authorization", "test-key");
         expected.put("X-LaunchDarkly-Tags", "application-id/" + LDPackageConsts.SDK_NAME + " application-name/" + LDPackageConsts.SDK_NAME +
                 " application-version/" + BuildConfig.VERSION_NAME + " application-version-name/" + BuildConfig.VERSION_NAME);
         Map<String, String> headers = headersToMap(
@@ -114,7 +114,7 @@ public class LDConfigTest {
         );
 
         assertEquals(3, headers.size());
-        assertEquals("api_key test-key, more", headers.get("authorization"));
+        assertEquals("test-key, more", headers.get("authorization"));
         assertEquals("value", headers.get("new"));
     }
 


### PR DESCRIPTION
Removes a very old prefix that hasn't been needed in awhile.  FDv2 endpoints give 400s if the prefix is included, that is what is motivating this fix now.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `Authorization` header format sent on all SDK HTTP requests; if any backend/proxy still expects the legacy `api_key ` prefix, requests could start failing. Test updates reduce regression risk but coverage is limited to mocked endpoints.
> 
> **Overview**
> Removes the legacy `api_key ` prefix from the SDK’s default `Authorization` header, sending the raw mobile key instead.
> 
> Updates unit/instrumentation tests (`LDClientEventTest`, `HttpConfigurationBuilderTest`, `LDConfigTest`) and deletes `LDUtil.AUTH_SCHEME` to reflect and enforce the new header value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21259556f6cb43c0cbf88c84d231e0de908b89bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->