### PR TITLE
chore: implements conditional inclusion of initializers

### DIFF
--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/ConnectivityManager.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/ConnectivityManager.java
@@ -363,7 +363,7 @@ class ConnectivityManager implements ContextDataManager.ContextSwitchListener {
             // selector is still empty (no fully-current payload yet). Once a non-empty selector
             // exists, subsequent rebuilds use synchronizers only.
             boolean includeInitializers =
-                    currentView == null || currentView.getSelector().isEmpty();
+                    view == null || view.getSelector().isEmpty();
             ((FDv2DataSourceBuilder) dataSourceFactory).setActiveMode(currentFDv2Mode, includeInitializers);
         }
 

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/ConnectivityManager.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/ConnectivityManager.java
@@ -256,8 +256,7 @@ class ConnectivityManager implements ContextDataManager.ContextSwitchListener {
         }
 
         DataSource existingDataSource = currentDataSource.get();
-        boolean isFDv2ModeSwitch = false;
-        
+
         // FDv2 path: resolve mode for both startup (mustReinitializeDataSource=true) and
         // state-change (mustReinitializeDataSource=false) cases.
         if (useFDv2ModeResolution) {
@@ -286,7 +285,6 @@ class ConnectivityManager implements ContextDataManager.ContextSwitchListener {
                     onCompletion.onSuccess(null);
                     return false;
                 }
-                isFDv2ModeSwitch = true;
                 mustReinitializeDataSource = true;
             }
             currentFDv2Mode = newMode;
@@ -361,9 +359,12 @@ class ConnectivityManager implements ContextDataManager.ContextSwitchListener {
         );
 
         if (useFDv2ModeResolution) {
-            // CONNMODE 2.0.1: mode switches only transition synchronizers, not initializers.
-            // TODO: SDK-2071 - refactor running initializers to use existence of selector
-            ((FDv2DataSourceBuilder) dataSourceFactory).setActiveMode(currentFDv2Mode, !isFDv2ModeSwitch);
+            // CSFDV2 5.3.8 / js-core FDv2DataManagerBase: include initializers only while the
+            // selector is still empty (no fully-current payload yet). Once a non-empty selector
+            // exists, subsequent rebuilds use synchronizers only.
+            boolean includeInitializers =
+                    currentView == null || currentView.getSelector().isEmpty();
+            ((FDv2DataSourceBuilder) dataSourceFactory).setActiveMode(currentFDv2Mode, includeInitializers);
         }
 
         DataSource dataSource = dataSourceFactory.build(clientContext);

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/FDv2DataSourceBuilder.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/FDv2DataSourceBuilder.java
@@ -36,7 +36,7 @@ class FDv2DataSourceBuilder implements ComponentConfigurer<DataSource>, Closeabl
     private final ModeResolutionTable resolutionTable;
 
     private ConnectionMode activeMode;
-    private boolean includeInitializers = true; // false during mode switches to skip initializers (CONNMODE 2.0.1)
+    private boolean includeInitializers = true; // start with initializers
     private ScheduledExecutorService sharedExecutor;
 
     FDv2DataSourceBuilder() {
@@ -80,8 +80,8 @@ class FDv2DataSourceBuilder implements ComponentConfigurer<DataSource>, Closeabl
      * Called by {@link ConnectivityManager} before each {@link #build} call.
      *
      * @param mode               the target connection mode
-     * @param includeInitializers true for initial startup / identify, false for mode switches
-     *                           (per CONNMODE 2.0.1: mode switches only transition synchronizers)
+     * @param includeInitializers true when the FDv2 selector is still empty (no fully-current
+     *                           payload in the flag store); false once a non-empty selector exists
      */
     void setActiveMode(@NonNull ConnectionMode mode, boolean includeInitializers) {
         this.activeMode = mode;

--- a/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/ConnectivityManagerTest.java
+++ b/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/ConnectivityManagerTest.java
@@ -18,6 +18,10 @@ import androidx.annotation.NonNull;
 
 import com.launchdarkly.sdk.LDContext;
 import com.launchdarkly.sdk.LDValue;
+import com.launchdarkly.sdk.android.DataModel.Flag;
+import com.launchdarkly.sdk.fdv2.ChangeSet;
+import com.launchdarkly.sdk.fdv2.ChangeSetType;
+import com.launchdarkly.sdk.fdv2.Selector;
 import com.launchdarkly.sdk.android.ConnectionInformation.ConnectionMode;
 import com.launchdarkly.sdk.android.LDConfig.Builder.AutoEnvAttributes;
 import com.launchdarkly.sdk.android.integrations.AutomaticModeSwitchingConfig;
@@ -46,6 +50,7 @@ import com.launchdarkly.sdk.android.subsystems.Synchronizer;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -1220,7 +1225,7 @@ public class ConnectivityManagerTest extends EasyMockSupport {
     }
 
     @Test
-    public void fdv2_modeSwitchDoesNotIncludeInitializers() throws Exception {
+    public void fdv2_modeSwitchIncludesInitializersWhenSelectorEmpty() throws Exception {
         BlockingQueue<Boolean> initializerIncluded = new LinkedBlockingQueue<>();
 
         Map<com.launchdarkly.sdk.android.ConnectionMode, ModeDefinition> table = new LinkedHashMap<>();
@@ -1256,6 +1261,61 @@ public class ConnectivityManagerTest extends EasyMockSupport {
         awaitStartUp();
         assertEquals(Boolean.TRUE, initializerIncluded.poll(1, TimeUnit.SECONDS));
         verifyForegroundDataSourceWasCreatedAndStarted(CONTEXT);
+
+        mockPlatformState.setAndNotifyForegroundChangeListeners(false);
+
+        verifyDataSourceWasStopped();
+        // Matches js-core FDv2DataManagerBase: includeInitializers = !selector — empty selector
+        // means the pipeline may still need initializer work after a mode change.
+        assertEquals(Boolean.TRUE, initializerIncluded.poll(2, TimeUnit.SECONDS));
+        requireValue(receivedClientContexts, 2, TimeUnit.SECONDS, "bg data source creation");
+        requireValue(startedDataSources, 2, TimeUnit.SECONDS, "bg data source started");
+        verifyAll();
+    }
+
+    @Test
+    public void fdv2_modeSwitchExcludesInitializersWhenSelectorNonEmpty() throws Exception {
+        BlockingQueue<Boolean> initializerIncluded = new LinkedBlockingQueue<>();
+
+        Map<com.launchdarkly.sdk.android.ConnectionMode, ModeDefinition> table = new LinkedHashMap<>();
+        table.put(com.launchdarkly.sdk.android.ConnectionMode.STREAMING, new ModeDefinition(
+                Collections.<DataSourceBuilder<Initializer>>singletonList(inputs -> null),
+                Collections.<DataSourceBuilder<Synchronizer>>singletonList(inputs -> null),
+                null
+        ));
+        table.put(com.launchdarkly.sdk.android.ConnectionMode.BACKGROUND, new ModeDefinition(
+                Collections.<DataSourceBuilder<Initializer>>singletonList(inputs -> null),
+                Collections.<DataSourceBuilder<Synchronizer>>singletonList(inputs -> null),
+                null
+        ));
+
+        FDv2DataSourceBuilder builder = new FDv2DataSourceBuilder(table, com.launchdarkly.sdk.android.ConnectionMode.STREAMING) {
+            @Override
+            public DataSource build(ClientContext clientContext) {
+                initializerIncluded.offer(readIncludeInitializersFlag(this));
+                receivedClientContexts.add(clientContext);
+                return MockComponents.successfulDataSource(clientContext, DATA,
+                        ConnectionMode.STREAMING, startedDataSources, stoppedDataSources);
+            }
+        };
+
+        eventProcessor.setOffline(false);
+        eventProcessor.setInBackground(false);
+        eventProcessor.setOffline(false);
+        eventProcessor.setInBackground(true);
+        eventProcessor.flush(); // CONNMODE 3.3.1: flush before background transition
+        replayAll();
+
+        createTestManager(defaultTestConfig(false, false), builder);
+        awaitStartUp();
+        assertEquals(Boolean.TRUE, initializerIncluded.poll(1, TimeUnit.SECONDS));
+
+        Flag flag = new FlagBuilder("flag1").version(1).build();
+        Map<String, Flag> items = new HashMap<>();
+        items.put(flag.getKey(), flag);
+        Selector selector = Selector.make(1, "state-1");
+        contextDataManager.apply(CONTEXT, new ChangeSet<>(
+                ChangeSetType.Full, selector, items, null, false));
 
         mockPlatformState.setAndNotifyForegroundChangeListeners(false);
 


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

SDK-2071

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes FDv2 rebuild behavior to sometimes run initializers during mode switches based on selector state, which can affect startup/reconnect correctness and performance of data source transitions. Risk is moderate and limited to FDv2 mode switching paths, with new tests covering empty vs non-empty selector cases.
> 
> **Overview**
> Updates FDv2 data-source rebuild logic so *initializers are included only until the flag-store selector becomes non-empty*, rather than being skipped on all mode switches.
> 
> `ConnectivityManager` now decides `includeInitializers` based on `view.getSelector().isEmpty()` when calling `FDv2DataSourceBuilder.setActiveMode(...)`, and associated comments/docs are updated. Tests are adjusted to reflect the new behavior and add coverage for both *empty selector* (initializers included) and *non-empty selector* (initializers excluded) mode-switch scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 198813bba4ccea78ed2cfcb5fd46bcfe15062ba6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->