### PR TITLE
chore: improves FDv2 DataSource logging

### DIFF
--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/FDv1PollingSynchronizer.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/FDv1PollingSynchronizer.java
@@ -188,4 +188,10 @@ final class FDv1PollingSynchronizer implements Synchronizer {
         } catch (IOException ignored) {
         }
     }
+
+    @Override
+    @NonNull
+    public String name() {
+        return "PollingSynchronizer(V1)";
+    }
 }

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/FDv2CacheInitializer.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/FDv2CacheInitializer.java
@@ -103,4 +103,10 @@ final class FDv2CacheInitializer implements Initializer {
     public void close() {
         // No-op: the cache read runs synchronously in run(), so there is nothing to cancel.
     }
+
+    @Override
+    @NonNull
+    public String name() {
+        return "CacheInitializer(V2)";
+    }
 }

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/FDv2DataSource.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/FDv2DataSource.java
@@ -451,9 +451,6 @@ final class FDv2DataSource implements DataSource {
                             failure.getMessage() != null ? failure.getMessage() : LogValues.exceptionSummary(failure)
                     );
                 }
-                if (failure instanceof InterruptedException) {
-                    Thread.currentThread().interrupt();
-                }
             } catch (CancellationException e) {
                 sink.setStatus(DataSourceState.INTERRUPTED, e);
             } catch (InterruptedException e) {
@@ -646,9 +643,6 @@ final class FDv2DataSource implements DataSource {
                                 synchronizer.name(),
                                 failure.getMessage() != null ? failure.getMessage() : LogValues.exceptionSummary(failure)
                         );
-                    }
-                    if (failure instanceof InterruptedException) {
-                        Thread.currentThread().interrupt();
                     }
                 } catch (CancellationException e) {
                     sink.setStatus(DataSourceState.INTERRUPTED, e);

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/FDv2DataSource.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/FDv2DataSource.java
@@ -4,11 +4,13 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.launchdarkly.logging.LDLogger;
+import com.launchdarkly.logging.LogValues;
 import com.launchdarkly.sdk.LDContext;
 import com.launchdarkly.sdk.android.subsystems.Callback;
 import com.launchdarkly.sdk.fdv2.ChangeSet;
 import com.launchdarkly.sdk.fdv2.ChangeSetType;
 import com.launchdarkly.sdk.fdv2.SourceResultType;
+import com.launchdarkly.sdk.fdv2.SourceSignal;
 import com.launchdarkly.sdk.android.subsystems.DataSourceState;
 import com.launchdarkly.sdk.android.subsystems.DataSourceUpdateSinkV2;
 import com.launchdarkly.sdk.android.subsystems.FDv2SourceResult;
@@ -47,7 +49,7 @@ final class FDv2DataSource implements DataSource {
     private final LDContext evaluationContext;
     private final DataSourceUpdateSinkV2 dataSourceUpdateSink;
     private static final String FDV1_FALLBACK_MESSAGE =
-            "Server signaled FDv1 fallback; switching to FDv1 polling synchronizer.";
+            "Falling back to an FDv1 fallback synchronizer.";
     private static final String INITIALIZER_ERROR = "Initializer error: {}";
     private static final String INITIALIZER_CANCELLED = "Initializer cancelled: {}";
     private static final String INITIALIZER_INTERRUPTED = "Initializer interrupted: {}";
@@ -66,6 +68,13 @@ final class FDv2DataSource implements DataSource {
     private final AtomicBoolean stopCalled = new AtomicBoolean(false);
     private final AtomicBoolean stopCompleted = new AtomicBoolean(false);
     private final List<Callback<Void>> pendingStopCallbacks = new ArrayList<>();
+
+    /**
+     * Avoid duplicate orchestration logs for the same synchronizer and {@link SourceSignal}.
+     */
+    private String lastLoggedSynchronizerDedupeName;
+
+    private SourceSignal lastLoggedSynchronizerDedupeStatus;
 
     // This future is set by either the worker thread terminating or stop() being called.
     private final LDAwaitFuture<Throwable> shutdownCause = new LDAwaitFuture<>();
@@ -180,7 +189,9 @@ final class FDv2DataSource implements DataSource {
         sharedExecutor.execute(() -> {
             try {
                 if (!sourceManager.hasAvailableSources()) {
-                    logger.info("No initializers or synchronizers; data source will not connect.");
+                    logger.warn(
+                            "LaunchDarkly client will not connect to LaunchDarkly for feature flag data due to no initializers or synchronizers configured."
+                    );
                     dataSourceUpdateSink.setStatus(DataSourceState.VALID, null);
                     tryCompleteStart(true, null);
                     return; // this will go to the finally block and block until stop sets shutdownCause
@@ -358,6 +369,8 @@ final class FDv2DataSource implements DataSource {
         boolean anyDataReceived = false;
         Initializer initializer = sourceManager.getNextInitializerAndSetActive();
         while (initializer != null) {
+            String initializerName = initializer.name();
+            logger.info("Initializer '{}' is starting.", initializerName);
             try {
                 FDv2SourceResult result = initializer.run().get();
 
@@ -386,6 +399,7 @@ final class FDv2DataSource implements DataSource {
                         ChangeSet<Map<String, DataModel.Flag>> changeSet = result.getChangeSet();
                         if (changeSet != null) {
                             sink.apply(context, changeSet);
+                            logger.info("Initialized via '{}'.", initializerName);
                             if (changeSet.getType() != ChangeSetType.None) {
                                 anyDataReceived = true;
                             }
@@ -405,6 +419,11 @@ final class FDv2DataSource implements DataSource {
                             switch (status.getState()) {
                                 case INTERRUPTED:
                                 case TERMINAL_ERROR:
+                                    logger.warn(
+                                        "Initializer '{}' failed: {}",
+                                        initializerName,
+                                        detailForThrowable(status.getError())
+                                    );
                                     sink.setStatus(DataSourceState.INTERRUPTED, status.getError());
                                     break;
                                 case SHUTDOWN:
@@ -417,14 +436,25 @@ final class FDv2DataSource implements DataSource {
                         break;
                 }
             } catch (ExecutionException e) {
-                logger.warn(INITIALIZER_ERROR, e.getCause() != null ? e.getCause().toString() : e.toString());
-                sink.setStatus(DataSourceState.INTERRUPTED, e.getCause() != null ? e.getCause() : e);
+                Throwable failure = e.getCause() != null ? e.getCause() : e;
+                sink.setStatus(DataSourceState.INTERRUPTED, failure);
+                if (!stopCalled.get()
+                        && !(failure instanceof CancellationException)
+                        && !(failure instanceof InterruptedException)) {
+                    logger.error(
+                            "Error running initializer '{}': {}",
+                            initializerName,
+                            failure.getMessage() != null ? failure.getMessage() : LogValues.exceptionSummary(failure)
+                    );
+                }
+                if (failure instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
             } catch (CancellationException e) {
-                logger.warn(INITIALIZER_CANCELLED, e.toString());
                 sink.setStatus(DataSourceState.INTERRUPTED, e);
             } catch (InterruptedException e) {
-                logger.warn(INITIALIZER_INTERRUPTED, e.toString());
                 sink.setStatus(DataSourceState.INTERRUPTED, e);
+                Thread.currentThread().interrupt();
                 return;
             }
             initializer = sourceManager.getNextInitializerAndSetActive();
@@ -449,6 +479,36 @@ final class FDv2DataSource implements DataSource {
         return list;
     }
 
+    private static String detailForThrowable(@Nullable Throwable error) {
+        if (error == null) {
+            return "unknown error";
+        }
+        String message = error.getMessage();
+        if (message != null && !message.isEmpty()) {
+            return message;
+        }
+        return error.toString();
+    }
+
+    private void resetSynchronizerStatusDedupe() {
+        lastLoggedSynchronizerDedupeName = null;
+        lastLoggedSynchronizerDedupeStatus = null;
+    }
+
+    private void maybeLogSynchronizerStatusChange(@Nullable String sourceName, @NonNull SourceSignal state) {
+        if (state == SourceSignal.GOODBYE) {
+            return;
+        }
+        if (sourceName != null
+                && sourceName.equals(lastLoggedSynchronizerDedupeName)
+                && state == lastLoggedSynchronizerDedupeStatus) {
+            return;
+        }
+        lastLoggedSynchronizerDedupeName = sourceName;
+        lastLoggedSynchronizerDedupeStatus = state;
+        logger.info("Synchronizer '{}' reported status: {}.", sourceName, state.name());
+    }
+
     private void runSynchronizers(
             @NonNull LDContext context,
             @NonNull DataSourceUpdateSinkV2 sink
@@ -456,6 +516,9 @@ final class FDv2DataSource implements DataSource {
         try {
             Synchronizer synchronizer = sourceManager.getNextAvailableSynchronizerAndSetActive();
             while (synchronizer != null) {
+                String synchronizerName = synchronizer.name();
+                logger.info("Synchronizer '{}' is starting.", synchronizerName);
+                resetSynchronizerStatusDedupe();
                 int synchronizerCount = sourceManager.getAvailableSynchronizerCount();
                 boolean isPrime = sourceManager.isPrimeSynchronizer();
                 try {
@@ -472,12 +535,17 @@ final class FDv2DataSource implements DataSource {
                                 FDv2DataSourceConditions.ConditionType ct = (FDv2DataSourceConditions.ConditionType) res;
                                 switch (ct) {
                                     case FALLBACK:
-                                        logger.debug("Synchronizer {} experienced an interruption; falling back to next synchronizer.",
-                                                synchronizer.getClass().getSimpleName());
+                                        logger.info(
+                                                "Fallback condition met, falling back from synchronizer '{}'.",
+                                                synchronizer.name()
+                                        );
                                         break;
                                     case RECOVERY:
-                                        logger.debug("The data source is attempting to recover to a higher priority synchronizer.");
                                         sourceManager.resetSourceIndex();
+                                        logger.info(
+                                                "Recovery condition met, moving from synchronizer '{}' to primary synchronizer.",
+                                                synchronizer.name()
+                                        );
                                         break;
                                 }
                                 running = false;
@@ -496,6 +564,7 @@ final class FDv2DataSource implements DataSource {
 
                             switch (result.getResultType()) {
                                 case CHANGE_SET:
+                                    resetSynchronizerStatusDedupe();
                                     ChangeSet<Map<String, DataModel.Flag>> changeSet = result.getChangeSet();
                                     if (changeSet != null) {
                                         sink.apply(context, changeSet);
@@ -508,16 +577,32 @@ final class FDv2DataSource implements DataSource {
                                     if (status != null) {
                                         switch (status.getState()) {
                                             case INTERRUPTED:
+                                                maybeLogSynchronizerStatusChange(
+                                                        synchronizer.name(),
+                                                        status.getState()
+                                                );
                                                 sink.setStatus(DataSourceState.INTERRUPTED, status.getError());
                                                 break;
                                             case SHUTDOWN:
-                                                // This synchronizer is shutting down cleanly/intentionally
+                                                maybeLogSynchronizerStatusChange(
+                                                        synchronizer.name(),
+                                                        status.getState()
+                                                );
+                                                logger.debug("Synchronizer shutdown.");
+                                                // Android: advance to the next synchronizer (differs from server,
+                                                // which exits the synchronizer phase on SHUTDOWN).
                                                 running = false;
                                                 break;
                                             case TERMINAL_ERROR:
-                                                // This synchronizer cannot recover; block it so the outer
-                                                // loop advances to the next available synchronizer.
+                                                maybeLogSynchronizerStatusChange(
+                                                        synchronizer.name(),
+                                                        status.getState()
+                                                );
                                                 sourceManager.blockCurrentSynchronizer();
+                                                logger.warn(
+                                                        "Synchronizer '{}' permanently failed and will not be used again until application restart.",
+                                                        synchronizer.name()
+                                                );
                                                 running = false;
                                                 sink.setStatus(DataSourceState.INTERRUPTED, status.getError());
                                                 break;
@@ -547,18 +632,34 @@ final class FDv2DataSource implements DataSource {
                         }
                     }
                 } catch (ExecutionException e) {
-                    logger.warn("Synchronizer error: {}", e.getCause() != null ? e.getCause().toString() : e.toString());
-                    sink.setStatus(DataSourceState.INTERRUPTED, e.getCause() != null ? e.getCause() : e);
+                    Throwable failure = e.getCause() != null ? e.getCause() : e;
+                    sink.setStatus(DataSourceState.INTERRUPTED, failure);
+                    if (!stopCalled.get()
+                            && !(failure instanceof CancellationException)
+                            && !(failure instanceof InterruptedException)) {
+                        logger.error(
+                                "Error running synchronizer '{}': {}",
+                                synchronizer.name(),
+                                failure.getMessage() != null ? failure.getMessage() : LogValues.exceptionSummary(failure)
+                        );
+                    }
+                    if (failure instanceof InterruptedException) {
+                        Thread.currentThread().interrupt();
+                    }
                 } catch (CancellationException e) {
-                    logger.warn("Synchronizer cancelled: {}", e.toString());
                     sink.setStatus(DataSourceState.INTERRUPTED, e);
                 } catch (InterruptedException e) {
-                    logger.warn("Synchronizer interrupted: {}", e.toString());
                     sink.setStatus(DataSourceState.INTERRUPTED, e);
+                    Thread.currentThread().interrupt();
                     return;
                 }
                 synchronizer = sourceManager.getNextAvailableSynchronizerAndSetActive();
             }
+            if (!stopCalled.get()) {
+                logger.warn("No more synchronizers available.");
+            }
+        } catch (Exception e) {
+            logger.error("Unexpected error in data source: {}", e.toString());
         } finally {
             sourceManager.close();
         }

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/FDv2DataSource.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/FDv2DataSource.java
@@ -399,7 +399,6 @@ final class FDv2DataSource implements DataSource {
                         ChangeSet<Map<String, DataModel.Flag>> changeSet = result.getChangeSet();
                         if (changeSet != null) {
                             sink.apply(context, changeSet);
-                            logger.info("Initialized via '{}'.", initializerName);
                             if (changeSet.getType() != ChangeSetType.None) {
                                 anyDataReceived = true;
                             }
@@ -408,9 +407,14 @@ final class FDv2DataSource implements DataSource {
                             if (!changeSet.getSelector().isEmpty()) {
                                 sink.setStatus(DataSourceState.VALID, null);
                                 tryCompleteStart(true, null);
+                                logger.info("Initialized via '{}'.", initializerName);
                                 return;
                             }
                             // Empty selector: partial data received, keep trying remaining initializers.
+                            logger.debug(
+                                    "Initializer '{}' returned data with an empty selector; continuing with remaining initializers.",
+                                    initializerName
+                            );
                         }
                         break;
                     case STATUS:

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/FDv2PollingInitializer.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/FDv2PollingInitializer.java
@@ -66,4 +66,10 @@ final class FDv2PollingInitializer extends FDv2PollingBase implements Initialize
         shutdownFuture.set(FDv2SourceResult.status(FDv2SourceResult.Status.shutdown(), false));
         closeRequestor();
     }
+
+    @Override
+    @NonNull
+    public String name() {
+        return "PollingInitializer(V2)";
+    }
 }

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/FDv2PollingSynchronizer.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/FDv2PollingSynchronizer.java
@@ -114,4 +114,10 @@ final class FDv2PollingSynchronizer extends FDv2PollingBase implements Synchroni
         shutdownFuture.set(FDv2SourceResult.status(FDv2SourceResult.Status.shutdown(), false));
         closeRequestor();
     }
+
+    @Override
+    @NonNull
+    public String name() {
+        return "PollingSynchronizer(V2)";
+    }
 }

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/FDv2StreamingSynchronizer.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/FDv2StreamingSynchronizer.java
@@ -465,4 +465,10 @@ final class FDv2StreamingSynchronizer implements Synchronizer {
         }
         protocolHandler.reset();
     }
+
+    @Override
+    @NonNull
+    public String name() {
+        return "StreamingSynchronizer(V2)";
+    }
 }

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/subsystems/Initializer.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/subsystems/Initializer.java
@@ -26,4 +26,16 @@ public interface Initializer extends Closeable {
      * @return a Future that completes with the result
      */
     Future<FDv2SourceResult> run();
+
+    /**
+     * Human-readable name for logging and diagnostics. Do not use this for influencing code behavior.
+     * <p>
+     * Implementations may override; the default uses the runtime class simple name.
+     *
+     * @return the name
+     */
+    default String name() {
+        String simple = getClass().getSimpleName();
+        return simple.isEmpty() ? getClass().getName() : simple;
+    }
 }

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/subsystems/Synchronizer.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/subsystems/Synchronizer.java
@@ -30,4 +30,16 @@ public interface Synchronizer extends Closeable {
      * @return a Future that completes with the next result (change set or status)
      */
     Future<FDv2SourceResult> next();
+
+    /**
+     * Human-readable name for logging and diagnostics. Do not use this for influencing code behavior.
+     * <p>
+     * Implementations may override; the default uses the runtime class simple name.
+     *
+     * @return the name
+     */
+    default String name() {
+        String simple = getClass().getSimpleName();
+        return simple.isEmpty() ? getClass().getName() : simple;
+    }
 }

--- a/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/FDv2DataSourceTest.java
+++ b/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/FDv2DataSourceTest.java
@@ -56,6 +56,8 @@ public class FDv2DataSourceTest {
 
     private static final long AWAIT_TIMEOUT_SECONDS = 10;
 
+    private static final long ORCHESTRATION_LOG_AWAIT_TIMEOUT_MS = AWAIT_TIMEOUT_SECONDS * 1000L;
+
     private ScheduledExecutorService executor;
 
     @Before
@@ -1907,5 +1909,274 @@ public class FDv2DataSourceTest {
 
         assertTrue(startCallback.await(AWAIT_TIMEOUT_SECONDS * 1000));
         stopDataSource(dataSource);
+    }
+
+    @Test
+    public void orchestrationLogging_noSourcesConfigured_logsWarnPerSpec() throws Exception {
+        MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
+        FDv2DataSource dataSource = buildDataSource(sink, Collections.emptyList(), Collections.emptyList());
+        AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
+        assertTrue(startCallback.await(AWAIT_TIMEOUT_SECONDS * 1000));
+        awaitLogContains(logging, "LaunchDarkly client will not connect to LaunchDarkly for feature flag data");
+        awaitLogContains(logging, "no initializers or synchronizers configured");
+        stopDataSource(dataSource);
+    }
+
+    @Test
+    public void orchestrationLogging_initializerStartAndInitializedVia_logsInfo() throws Exception {
+        MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
+        FDv2DataSource dataSource = buildDataSource(sink,
+                Collections.singletonList(() -> new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false))),
+                Collections.emptyList());
+        AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
+        assertTrue(startCallback.await(AWAIT_TIMEOUT_SECONDS * 1000));
+        awaitLogContains(logging, "Initializer 'MockInitializer' is starting.");
+        awaitLogContains(logging, "Initialized via 'MockInitializer'.");
+        stopDataSource(dataSource);
+    }
+
+    @Test
+    public void orchestrationLogging_initializerFailedNonException_logsWarnWithDetail() throws Exception {
+        MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
+        FDv2DataSource dataSource = buildDataSource(sink,
+                Collections.singletonList(() -> new MockInitializer(
+                        FDv2SourceResult.status(FDv2SourceResult.Status.terminalError(new RuntimeException("bootstrap read failed")), false))),
+                Collections.emptyList());
+        AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
+        awaitExpectingError(startCallback);
+        awaitLogContains(logging, "Initializer 'MockInitializer' failed:");
+        awaitLogContains(logging, "bootstrap read failed");
+    }
+
+    @Test
+    public void orchestrationLogging_synchronizerStarting_logsInfo() throws Exception {
+        MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
+        FDv2DataSource dataSource = buildDataSource(sink,
+                Collections.emptyList(),
+                Collections.singletonList(() -> new MockQueuedSynchronizer(
+                        FDv2SourceResult.changeSet(makeChangeSet(false), false))));
+        AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
+        assertTrue(startCallback.await(AWAIT_TIMEOUT_SECONDS * 1000));
+        awaitLogContains(logging, "Synchronizer 'MockQueuedSynchronizer' is starting.");
+        stopDataSource(dataSource);
+    }
+
+    @Test
+    public void orchestrationLogging_synchronizerInterruptedStatus_logsInfo() throws Exception {
+        MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
+        FDv2DataSource dataSource = buildDataSource(sink,
+                Collections.emptyList(),
+                Collections.singletonList(() -> new MockQueuedSynchronizer(
+                        FDv2SourceResult.changeSet(makeChangeSet(false), false),
+                        interrupted())));
+        AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
+        assertTrue(startCallback.await(AWAIT_TIMEOUT_SECONDS * 1000));
+        awaitLogContains(logging, "Synchronizer 'MockQueuedSynchronizer' reported status: INTERRUPTED.");
+        stopDataSource(dataSource);
+    }
+
+    @Test
+    public void orchestrationLogging_consecutiveDuplicateStatus_logsOnce() throws Exception {
+        MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
+        // Two INTERRUPTEDs in a row (deduped), then a change set; fourth next() blocks until stop().
+        // Second synchronizer tier only SHUTDOWN so the outer loop exits (same factory cannot safely repeat the queue).
+        MockQueuedSynchronizer firstSync = new MockQueuedSynchronizer(
+                interrupted(),
+                interrupted(),
+                FDv2SourceResult.changeSet(makeChangeSet(false), false));
+        FDv2DataSource dataSource = buildDataSource(sink,
+                Collections.emptyList(),
+                Arrays.asList(
+                        () -> firstSync,
+                        () -> new MockQueuedSynchronizer(
+                                FDv2SourceResult.status(FDv2SourceResult.Status.shutdown(), false))));
+        AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
+        assertTrue(startCallback.await(AWAIT_TIMEOUT_SECONDS * 1000));
+        sink.awaitApplyCount(1, AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        awaitLogContains(logging, "reported status: INTERRUPTED.");
+        assertEquals(1, logLineCountContaining(logging, "reported status: INTERRUPTED."));
+        stopDataSource(dataSource);
+    }
+
+    @Test
+    public void orchestrationLogging_fallback_logsInfo() throws Exception {
+        MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
+        BlockingQueue<Boolean> secondCalledQueue = new LinkedBlockingQueue<>();
+        FDv2DataSource dataSource = buildDataSource(sink,
+                Collections.emptyList(),
+                Arrays.asList(
+                        () -> new MockQueuedSynchronizer(
+                                FDv2SourceResult.changeSet(makeChangeSet(false), false),
+                                interrupted()),
+                        () -> {
+                            secondCalledQueue.offer(true);
+                            return new MockQueuedSynchronizer(
+                                    FDv2SourceResult.changeSet(makeChangeSet(false), false));
+                        }),
+                1, 300);
+        AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
+        assertTrue(startCallback.await(AWAIT_TIMEOUT_SECONDS * 1000));
+        assertNotNull(secondCalledQueue.poll(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+        awaitLogContains(logging, "Fallback condition met, falling back from synchronizer 'MockQueuedSynchronizer'.");
+        stopDataSource(dataSource);
+    }
+
+    @Test
+    public void orchestrationLogging_recovery_logsInfo() throws Exception {
+        MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
+        MockQueuedSynchronizer firstSync = new MockQueuedSynchronizer(
+                FDv2SourceResult.changeSet(makeChangeSet(false), false),
+                interrupted());
+        MockQueuedSynchronizer secondSync = new MockQueuedSynchronizer(
+                FDv2SourceResult.changeSet(makeChangeSet(false), false));
+        FDv2DataSource dataSource = buildDataSource(sink,
+                Collections.emptyList(),
+                Arrays.asList(
+                        () -> firstSync,
+                        () -> secondSync),
+                1, 2);
+        AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
+        try {
+            assertTrue(startCallback.await(AWAIT_TIMEOUT_SECONDS * 1000));
+            awaitLogContains(logging,
+                    "Recovery condition met, moving from synchronizer 'MockQueuedSynchronizer' to primary synchronizer.");
+        } finally {
+            stopDataSource(dataSource);
+        }
+    }
+
+    @Test
+    public void orchestrationLogging_fdv1Fallback_logsInfo() throws Exception {
+        MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
+        MockQueuedSynchronizer fdv2Sync = new MockQueuedSynchronizer(
+                FDv2SourceResult.changeSet(makeChangeSet(true), true));
+        MockQueuedSynchronizer fdv1Sync = new MockQueuedSynchronizer(
+                FDv2SourceResult.changeSet(makeChangeSet(true), false));
+        FDv2DataSource dataSource = new FDv2DataSource(
+                CONTEXT,
+                Collections.emptyList(),
+                Collections.singletonList(() -> fdv2Sync),
+                () -> fdv1Sync,
+                sink,
+                executor,
+                logging.logger);
+        AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
+        assertTrue(startCallback.await(AWAIT_TIMEOUT_SECONDS * 1000));
+        awaitLogContains(logging, "Falling back to an FDv1 fallback synchronizer.");
+        stopDataSource(dataSource);
+    }
+
+    @Test
+    public void orchestrationLogging_permanentFailure_logsWarn() throws Exception {
+        MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
+        FDv2DataSource dataSource = buildDataSource(sink,
+                Collections.emptyList(),
+                Collections.singletonList(() -> new MockQueuedSynchronizer(terminalError())));
+        AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
+        awaitExpectingError(startCallback);
+        awaitLogContains(logging,
+                "Synchronizer 'MockQueuedSynchronizer' permanently failed and will not be used again until application restart.");
+    }
+
+    @Test
+    public void orchestrationLogging_allSynchronizersExhausted_logsWarn() throws Exception {
+        MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
+        FDv2DataSource dataSource = buildDataSource(sink,
+                Collections.emptyList(),
+                Arrays.asList(
+                        () -> new MockQueuedSynchronizer(terminalError()),
+                        () -> new MockQueuedSynchronizer(terminalError()),
+                        () -> new MockQueuedSynchronizer(terminalError())));
+        AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
+        awaitExpectingError(startCallback);
+        awaitLogContains(logging, "No more synchronizers available.");
+    }
+
+    @Test
+    public void orchestrationLogging_initializerException_logsError() throws Exception {
+        MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
+        FDv2DataSource dataSource = buildDataSource(sink,
+                Arrays.asList(
+                        () -> new MockInitializer(new RuntimeException("init-boom")),
+                        () -> new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false))),
+                Collections.emptyList());
+        AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
+        assertTrue(startCallback.await(AWAIT_TIMEOUT_SECONDS * 1000));
+        awaitLogContains(logging, "Error running initializer 'MockInitializer':");
+        awaitLogContains(logging, "init-boom");
+    }
+
+    @Test
+    public void orchestrationLogging_initializerInterrupted_suppressesErrorLog() throws Exception {
+        MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
+        FDv2DataSource dataSource = buildDataSource(sink,
+                Arrays.asList(
+                        () -> new MockInitializer(new InterruptedException("interrupted")),
+                        () -> new MockInitializer(FDv2SourceResult.changeSet(makeChangeSet(true), false))),
+                Collections.emptyList());
+        AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
+        assertTrue(startCallback.await(AWAIT_TIMEOUT_SECONDS * 1000));
+        awaitLogContains(logging, "Initialized via 'MockInitializer'.");
+        assertFalse(logging.logCapture.getMessageStrings().stream()
+                .anyMatch(s -> s.contains("ERROR:") && s.contains("Error running initializer")));
+        stopDataSource(dataSource);
+    }
+
+    @Test
+    public void orchestrationLogging_synchronizerException_logsError() throws Exception {
+        MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
+        FDv2DataSource dataSource = buildDataSource(sink,
+                Collections.emptyList(),
+                Arrays.asList(
+                        () -> new MockSynchronizer(new RuntimeException("sync-boom")),
+                        () -> new MockSynchronizer(FDv2SourceResult.changeSet(makeChangeSet(false), false))));
+        AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
+        assertTrue(startCallback.await(AWAIT_TIMEOUT_SECONDS * 1000));
+        awaitLogContains(logging, "Error running synchronizer 'MockSynchronizer':");
+        awaitLogContains(logging, "sync-boom");
+        stopDataSource(dataSource);
+    }
+
+    @Test
+    public void orchestrationLogging_synchronizerInterrupted_suppressesErrorLog() throws Exception {
+        MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
+        FDv2DataSource dataSource = buildDataSource(sink,
+                Collections.emptyList(),
+                Arrays.asList(
+                        () -> new MockSynchronizer(new InterruptedException("interrupted")),
+                        () -> new MockSynchronizer(FDv2SourceResult.changeSet(makeChangeSet(false), false))));
+        AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
+        assertTrue(startCallback.await(AWAIT_TIMEOUT_SECONDS * 1000));
+        sink.awaitApplyCount(1, AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertFalse(logging.logCapture.getMessageStrings().stream()
+                .anyMatch(s -> s.contains("ERROR:") && s.contains("Error running synchronizer")));
+        stopDataSource(dataSource);
+    }
+
+    /**
+     * Polls captured log messages until one contains {@code substring}, or fails after {@code timeoutMs}.
+     * Use this instead of immediate {@code assert*Logged} so assertions are not racy with the worker thread.
+     */
+    private void awaitLogContains(LogCaptureRule rule, String substring, long timeoutMs) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (System.currentTimeMillis() < deadline) {
+            for (String s : rule.logCapture.getMessageStrings()) {
+                if (s.contains(substring)) {
+                    return;
+                }
+            }
+            Thread.sleep(10);
+        }
+        fail("Timed out after " + timeoutMs + " ms waiting for log containing: " + substring);
+    }
+
+    private void awaitLogContains(LogCaptureRule rule, String substring) throws InterruptedException {
+        awaitLogContains(rule, substring, ORCHESTRATION_LOG_AWAIT_TIMEOUT_MS);
+    }
+
+    private static long logLineCountContaining(LogCaptureRule rule, String substring) {
+        return rule.logCapture.getMessageStrings().stream()
+                .filter(s -> s.contains(substring))
+                .count();
     }
 }


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

Updates Android FDv2 Data Source logging to meet SDK Specs orchestration logging requirements.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly logging/diagnostics changes, but it updates public `Initializer`/`Synchronizer` interfaces and adjusts error/interrupt handling in `FDv2DataSource`, which could affect runtime behavior and downstream implementations.
> 
> **Overview**
> Updates FDv2 data source orchestration logging to meet spec: logs when no sources are configured, when each `Initializer`/`Synchronizer` starts, when initialization completes via a specific initializer, and when fallback/recovery/permanent failure/exhaustion occurs.
> 
> Adds a `name()` method (defaulting to class simple name) to `Initializer` and `Synchronizer`, and overrides it in built-in implementations (polling/streaming/cache/FDv1 fallback) to produce stable human-readable identifiers; synchronizer status logs are deduped to avoid repeated messages.
> 
> Tightens failure handling and log levels: formats error details more consistently, suppresses noisy error logs for stop/cancel/interrupt cases (and re-interrupts the thread on `InterruptedException`), and adds tests that assert the new orchestration log messages and dedupe behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb1671c6ddf95f408e7516c92ddbd42f98862280. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->