### PR TITLE
ci: fixing release please permissions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,6 +28,9 @@ jobs:
   call-workflow-publish:
     needs: release-please
     uses: ./.github/workflows/publish.yml
+    permissions:
+      id-token: write
+      contents: write
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     with:
       run_tests: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adjusts GitHub Actions workflow permissions for the `call-workflow-publish` job, affecting CI/release automation but not application runtime code.
> 
> **Overview**
> Ensures the `call-workflow-publish` job in `release-please.yml` explicitly requests `id-token: write` and `contents: write` permissions when invoking the reusable `publish.yml` workflow, so the publish step has the access it needs after a release is created.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11779f19583cbd7464a218e1d30d7a4ef4977b4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->