### PR TITLE
ci: grant pull-requests:read so lint-pr-title workflow starts

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   lint-pr-title:
     uses: launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml@main


### PR DESCRIPTION
## Summary

Adds `permissions: pull-requests: read` at the workflow level in `.github/workflows/lint-pr-title.yml`. The reusable workflow at `launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml` now declares `permissions: pull-requests: read` at the job level (per launchdarkly/gh-actions#86), and a reusable workflow can only request a subset of permissions the caller grants. Without an explicit `permissions` block in the caller, the called job fails with `startup_failure`.

Same fix as launchdarkly/sdk-meta#429, applied across SDK repositories.

## Review & Testing Checklist for Human

- [ ] Verify the `Lint PR title` workflow run on this PR completes successfully (no `startup_failure`)

### Notes

This is part of a batch fix applied to all SDK repos that use the reusable `lint-pr-title` workflow. No application code is changed.

Link to Devin session: https://app.devin.ai/sessions/c7b96da5c9074500aa684bc9a9ba1c31
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that only adjusts GitHub Actions permissions and does not affect application code.
> 
> **Overview**
> Ensures the reusable `lint-pr-title` workflow can run on `pull_request_target` events by explicitly adding **workflow-level** `permissions: pull-requests: read`, preventing `startup_failure` due to insufficient caller permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 564512985aea051389b10ea86c3779b6b55c0fdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->