### PR TITLE
fix: track order processing to forward according contracts

### DIFF
--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/HookRunner.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/HookRunner.java
@@ -120,7 +120,9 @@ public class HookRunner {
         }
 
         TrackSeriesContext seriesContext = new TrackSeriesContext(key, context, data, metricValue);
-        for (int i = hooks.size() - 1; i >= 0; i--) {
+        // The track series has only an "after" stage, so hooks run in registration order, as required by
+        // the shared SDK contract tests (unlike afterEvaluation/afterIdentify, which run in reverse).
+        for (int i = 0; i < hooks.size(); i++) {
             Hook currentHook = hooks.get(i);
             try {
                 currentHook.afterTrack(seriesContext);

--- a/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/HookRunnerTest.java
+++ b/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/HookRunnerTest.java
@@ -362,7 +362,8 @@ public class HookRunnerTest extends EasyMockSupport {
         runner.afterTrack(key, context, data, metricValue);
 
         verifyAll();
-        assertEquals(afterTrackOrder, List.of("c", "b", "a"));
+        // afterTrack runs in registration order (forward), unlike the reversed after-evaluation/identify stages.
+        assertEquals(afterTrackOrder, List.of("a", "b", "c"));
     }
 
     @Test public void usesAddedHookInFutureInvocations() {


### PR DESCRIPTION
## Overview

Fixes the execution order of `afterTrack` hooks so they run in **registration (forward) order**, matching the shared cross-SDK contract tests and the other LaunchDarkly client SDKs.

## Background

`HookRunner.afterTrack` was iterating over hooks in **reverse** registration order:

```java
for (int i = hooks.size() - 1; i >= 0; i--) { ... }
```

That reversal is correct for `afterEvaluation`/`afterIdentify`, which mirror their `before*` stages (onion model). But the **track** series has no `before` stage to unwind, so it must run forward. The shared contract suite (`launchdarkly/sdk-test-harness`, `sdktests/common_tests_hooks.go`) enforces this:

- `executesAfterTrackHooksInRegistrationOrder` asserts the observed order equals the registration order, with the message *"afterTrack hooks must execute in the order of hook registration"*.
- The comment there explicitly notes afterTrack is forward, "unlike afterEvaluation/afterIdentify which run in reverse-registration order."

As a result, the contract test `hooks/track/executes afterTrack hooks in registration order` was failing (expected `[0,1,2]`, actual `[2,1,0]`).


## Notes

This aligns Android with the iOS SDK fix for the same issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix in hook ordering for track events; aligns with other LaunchDarkly SDKs and contract tests, with no auth or data-path changes.
> 
> **Overview**
> **`HookRunner.afterTrack`** now invokes registered hooks in **forward registration order** instead of reverse. The track hook series has no `beforeTrack` stage, so reverse iteration (used for `afterEvaluation` / `afterIdentify` to unwind paired `before*` hooks) was incorrect and failed shared cross-SDK contract tests.
> 
> **`HookRunnerTest`** updates the multi-hook order assertion from `c, b, a` to `a, b, c` and documents that `afterTrack` is forward-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b90c6e44042c8ef48890402300c43fd019df7c70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->