### PR TITLE
fix: set 401 guard before notifying error callback to prevent restart race

### DIFF
--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/StreamingDataSource.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/StreamingDataSource.java
@@ -64,7 +64,9 @@ final class StreamingDataSource implements DataSource {
     private final FeatureFetcher fetcher;
     private final boolean streamEvenInBackground;
     private volatile boolean running = false;
-    private boolean connection401Error = false;
+    // volatile because it is written from the EventSource background thread (onError)
+    // and read from start(), which may be invoked on a different thread.
+    private volatile boolean connection401Error = false;
     private final DiagnosticStore diagnosticStore;
     private long eventSourceStarted;
     private final LDLogger logger;
@@ -133,11 +135,14 @@ final class StreamingDataSource implements DataSource {
                         if (code >= 400 && code < 500) {
                             logger.error("Encountered non-retriable error: {}. Aborting connection to stream. Verify correct Mobile Key and Stream URI", code);
                             running = false;
-                            resultCallback.onError(new LDInvalidResponseCodeFailure("Unexpected Response Code From Stream Connection", t, code, false));
+                            // Establish the terminal 401 state before notifying the callback. A consumer
+                            // may react to the error by synchronously calling start() again, and the
+                            // connection401Error guard must already be set so that retry is a no-op.
                             if (code == 401) {
                                 connection401Error = true;
                                 dataSourceUpdateSink.shutDown();
                             }
+                            resultCallback.onError(new LDInvalidResponseCodeFailure("Unexpected Response Code From Stream Connection", t, code, false));
                             stop(null);
                         } else {
                             eventSourceStarted = System.currentTimeMillis();

--- a/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/StreamingDataSourceTest.java
+++ b/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/StreamingDataSourceTest.java
@@ -617,9 +617,8 @@ public class StreamingDataSourceTest {
             LDInvalidResponseCodeFailure failure = (LDInvalidResponseCodeFailure) error;
             assertEquals(401, failure.getResponseCode());
             assertFalse(failure.isRetryable());
-            // The background thread calls resultCallback.onError() before
-            // dataSourceUpdateSink.shutDown(), so shutDownCalled may not be true yet.
-            // Poll briefly to allow the background thread to complete.
+            // shutDown() runs on the EventSource background thread, so poll briefly
+            // to allow that thread to complete before asserting.
             long deadline = System.currentTimeMillis() + 1000;
             while (!dataSourceUpdateSink.shutDownCalled && System.currentTimeMillis() < deadline) {
                 Thread.sleep(10);


### PR DESCRIPTION
## Summary

`StreamingDataSourceTest.startWithHttp401PreventsSubsequentStart` was intermittently failing in CI:

```
com.launchdarkly.sdk.android.StreamingDataSourceTest > startWithHttp401PreventsSubsequentStart FAILED
    java.lang.AssertionError at StreamingDataSourceTest.java:697
```

The root cause is a race in the production code, not the test.

## Root cause

In `StreamingDataSource.onError()`, when the stream returns a `401`, the terminal-state guard `connection401Error` was set **after** the error was delivered to the consumer:

```java
running = false;
resultCallback.onError(...);   // unblocks the consumer/test waiting on the error
if (code == 401) {
    connection401Error = true; // set too late
    dataSourceUpdateSink.shutDown();
}
```

`start()` only proceeds when `!running && !connection401Error`. A consumer that reacts to the error by synchronously calling `start()` again (which the test does immediately after `awaitError()` returns) could run **before** the background EventSource thread set `connection401Error = true`, slipping past the guard and opening a second connection. That second connection then emitted a callback and tripped `assertNull`.

Two contributing factors:
- **Ordering:** the guard was set after the error callback that signals completion.
- **Visibility:** `connection401Error` was a non-`volatile` field written on the EventSource background thread and read from `start()` on another thread.

## Changes

- **`StreamingDataSource.java`**
  - Set `connection401Error = true` (and call `dataSourceUpdateSink.shutDown()`) **before** invoking `resultCallback.onError(...)`, so the terminal 401 state is established before any consumer can react and retry.
  - Marked `connection401Error` as `volatile` for cross-thread visibility (mirrors `running`).
- **`StreamingDataSourceTest.java`**
  - Updated a now-stale comment in `startWithHttp401ShutsDownSink` that described the old `onError`-before-`shutDown` ordering.

Because the error is delivered through a `BlockingQueue` (`add`/`poll`), the reordering also provides a happens-before edge guaranteeing the consumer's subsequent `start()` observes the guard — the race is eliminated deterministically rather than masked with timing.

## Behavioral impact

On a `401`, `shutDown()` and the guard are now established before the error is reported to the consumer. The error reported, its retryability, and the eventual state are unchanged; only the relative ordering within the failure handler is tightened. `startWithHttp401ShutsDownSink` continues to pass (it polls for `shutDownCalled`, which is now set slightly earlier).

## Test plan

- [x] `startWithHttp401PreventsSubsequentStart` passes 6/6 consecutive runs (was flaky).
- [x] Full `StreamingDataSourceTest` class passes.
- [ ] CI `:launchdarkly-android-client-sdk:testDebugUnitTest` green.

## Related

Supersedes stale drafts #332 (same approach) and #337 (test-only workaround).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ordering and visibility of stream 401 handling in the data source path; impact is limited to auth-failure shutdown but affects connection lifecycle under concurrency.
> 
> **Overview**
> Fixes a **race** when the flag stream returns **401**: callers could invoke `start()` again before the terminal guard was visible, reopening the stream and causing flaky tests.
> 
> In `StreamingDataSource.onError()`, the handler now sets **`connection401Error`** and calls **`dataSourceUpdateSink.shutDown()`** *before* **`resultCallback.onError()`**, so any synchronous retry after the error sees the guard. **`connection401Error`** is also **`volatile`** so writes from the EventSource thread are visible to **`start()`** on other threads.
> 
> A unit test comment was updated to match the new ordering; reported errors and retry semantics are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82eba24d4732db8550ea32be0badc76e0f5b7753. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->