### PR TITLE
test: make callbackNotFiredBeforeDebounceWindow deterministic

### DIFF
--- a/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/StateDebounceManagerTest.java
+++ b/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/StateDebounceManagerTest.java
@@ -52,15 +52,21 @@ public class StateDebounceManagerTest {
     }
 
     @Test
-    public void callbackNotFiredBeforeDebounceWindow() throws InterruptedException {
+    public void callbackNotFiredBeforeDebounceWindow() {
+        // Uses a manually-driven executor instead of Thread.sleep so the test is deterministic:
+        // a wall-clock "should not have fired yet" assertion is flaky on loaded CI runners, where
+        // the short pre-window sleep can overshoot the debounce window and let the timer fire.
         AtomicInteger callCount = new AtomicInteger(0);
-        StateDebounceManager mgr = createManager(true, true, callCount::incrementAndGet);
+        ManualTaskExecutor manualExecutor = new ManualTaskExecutor();
+        StateDebounceManager mgr = new StateDebounceManager(
+                true, true, manualExecutor, TEST_DEBOUNCE_MS, callCount::incrementAndGet);
 
+        // The state change schedules the debounce timer but must not fire the callback yet.
         mgr.setNetworkAvailable(false);
-        Thread.sleep(TEST_DEBOUNCE_MS / 3);
         assertEquals("callback should not fire before debounce window", 0, callCount.get());
 
-        Thread.sleep(TEST_DEBOUNCE_MS * 3);
+        // Once the debounce timer fires, the callback runs exactly once.
+        manualExecutor.runPendingTasks();
         assertEquals(1, callCount.get());
 
         mgr.close();


### PR DESCRIPTION
## Summary

`StateDebounceManagerTest.callbackNotFiredBeforeDebounceWindow` is a wall-clock timing test that flakes on loaded CI runners, failing the `Build and Test` workflow on `main` and blocking the release-please publish:

```
com.launchdarkly.sdk.android.StateDebounceManagerTest > callbackNotFiredBeforeDebounceWindow FAILED
    java.lang.AssertionError at StateDebounceManagerTest.java:61
```

The old test scheduled a 50ms debounce timer, slept `TEST_DEBOUNCE_MS / 3` (~16ms), then asserted the callback had **not** fired yet. On a loaded runner that short sleep can overshoot the 50ms window, so the timer fires and the assertion fails.

This switches the test to the deterministic `ManualTaskExecutor` pattern already established in #359 (for `timerResetsOnEachEvent`). The scheduled debounce task now only runs when the test explicitly drives it via `runPendingTasks()`, removing all wall-clock dependence while preserving the original intent (timer scheduled but not yet fired → callback fires exactly once when it does).

## Test plan

- [x] `./gradlew :launchdarkly-android-client-sdk:testDebugUnitTest --tests "com.launchdarkly.sdk.android.StateDebounceManagerTest"` passes
- [x] Full `:launchdarkly-android-client-sdk:testDebugUnitTest` suite passes (`BUILD SUCCESSFUL`)
- [x] No new lint errors

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production or SDK behavior is modified.
> 
> **Overview**
> **`StateDebounceManagerTest.callbackNotFiredBeforeDebounceWindow`** no longer relies on wall-clock sleeps. It now wires **`StateDebounceManager`** to **`ManualTaskExecutor`** (same approach as **`timerResetsOnEachEvent`**) so the debounce task only runs when the test calls **`runPendingTasks()`**.
> 
> The test still checks that a state change schedules the timer without firing the reconcile callback immediately, then that the callback runs exactly once after the timer is driven. **`InterruptedException`** was dropped from the test signature because sleeps were removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fab29d557469a092314508f5ac2c44131a6ff085. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->