### PR TITLE
test: fix flaky fdv2_rapidStateChangesCoalesceIntoOneRebuild

### DIFF
--- a/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/ConnectivityManagerTest.java
+++ b/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/ConnectivityManagerTest.java
@@ -4,6 +4,7 @@ import static com.launchdarkly.sdk.android.TestUtil.requireNoMoreValues;
 import static com.launchdarkly.sdk.android.TestUtil.requireValue;
 import static org.easymock.EasyMock.anyBoolean;
 import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.checkOrder;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -1461,19 +1462,27 @@ public class ConnectivityManagerTest extends EasyMockSupport {
         verifyForegroundDataSourceWasCreatedAndStarted(CONTEXT);
         verifyAll();
 
-        // After startup, the rapid connectivity changes call updateEventProcessor in
-        // parallel threads, so ordering is nondeterministic. Use anyTimes().
+        // After startup, the rapid connectivity changes call updateEventProcessor, which
+        // invokes setOffline then setInBackground once per change. The number of changes is
+        // nondeterministic, so we use anyTimes(). We also disable order checking on this
+        // strict mock: each updateEventProcessor call repeats the (setOffline, setInBackground)
+        // pair, which a strict mock would otherwise reject as out-of-order once the first
+        // setInBackground has been consumed.
         resetAll();
+        checkOrder(eventProcessor, false);
         eventProcessor.setOffline(anyBoolean());
         expectLastCall().anyTimes();
         eventProcessor.setInBackground(anyBoolean());
         expectLastCall().anyTimes();
         replayAll();
 
-        // Fire multiple rapid connectivity changes — debounce should coalesce them
-        mockPlatformState.setAndNotifyConnectivityChangeListeners(false);
-        mockPlatformState.setAndNotifyConnectivityChangeListeners(true);
-        mockPlatformState.setAndNotifyConnectivityChangeListeners(false);
+        // Fire multiple rapid connectivity changes — debounce should coalesce them.
+        // Deliver the burst on a single thread so the listener observes the values in a
+        // deterministic order ending on `false`. Three separate setAndNotify... calls each
+        // spawn their own thread, which can reorder so that `true` (the baseline) is applied
+        // last; the debouncer's A→B→C→A dedup would then suppress the rebuild and no data
+        // source would ever be stopped, flaking verifyDataSourceWasStopped() below.
+        mockPlatformState.setAndNotifyConnectivityChangeListenersInSequence(false, true, false);
 
         // Should result in exactly one data source rebuild (to OFFLINE)
         verifyDataSourceWasStopped();

--- a/shared-test-code/src/main/java/com/launchdarkly/sdk/android/MockPlatformState.java
+++ b/shared-test-code/src/main/java/com/launchdarkly/sdk/android/MockPlatformState.java
@@ -72,6 +72,25 @@ public class MockPlatformState implements PlatformState {
         }).start();
     }
 
+    /**
+     * Notifies connectivity-change listeners with each value in {@code values}, in order, on a
+     * single background thread. Unlike repeated {@link #setAndNotifyConnectivityChangeListeners}
+     * calls — which each spawn their own thread and can therefore deliver notifications out of
+     * order — this delivers the whole sequence deterministically. The last value becomes the
+     * reported network state. Use this when a test depends on the final state after a burst of
+     * rapid changes (e.g. debounce coalescing).
+     */
+    public void setAndNotifyConnectivityChangeListenersInSequence(boolean... values) {
+        new Thread(() -> {
+            for (boolean value : values) {
+                this.networkAvailable = value;
+                for (ConnectivityChangeListener listener : connectivityChangeListeners) {
+                    listener.onConnectivityChanged(value);
+                }
+            }
+        }).start();
+    }
+
     public void setAndNotifyForegroundChangeListeners(boolean foreground) {
         this.foreground = foreground;
         new Thread(() -> {


### PR DESCRIPTION
## Summary

`ConnectivityManagerTest.fdv2_rapidStateChangesCoalesceIntoOneRebuild` intermittently failed CI (e.g. the `Build and Test` run on `main`) with:

```
java.lang.AssertionError: timed out waiting for stopping of data source
    at ConnectivityManagerTest.verifyDataSourceWasStopped(ConnectivityManagerTest.java:916)
```

Two latent issues combined to make it flaky:

**1. Strict-mock call ordering.** After `resetAll()`, the test records `setOffline(any).anyTimes()` then `setInBackground(any).anyTimes()` on a `MockType.STRICT` `eventProcessor` mock. Each `updateEventProcessor()` call repeats the `(setOffline, setInBackground)` pair, but a strict mock enforces call **order** — so the second connectivity change's `setOffline` is rejected as an unexpected call and throws on the listener thread, aborting it before `setNetworkAvailable()` runs. The captured `system-err` showed exactly this:

```
Unexpected method call EventProcessor.setOffline(false):
  EventProcessor.setInBackground(<any>): expected: at least 0, actual: 1
```

`anyTimes()` only relaxes the *count*, not the *order*. Fixed by disabling order checking for this phase with `checkOrder(eventProcessor, false)`.

**2. Notification reordering.** `MockPlatformState.setAndNotifyConnectivityChangeListeners` spawns a new thread per call, so three rapid changes (`false`, `true`, `false`) can be delivered out of order. If `true` (the baseline) lands last, the debouncer's A→B→C→A dedup suppresses the rebuild and no data source is ever stopped. Added `setAndNotifyConnectivityChangeListenersInSequence(...)` which delivers a burst deterministically on a single thread, ending on `false`, while preserving the "rapid changes" intent.

The racing version passed locally only by luck; both issues are real races independent of CI load.

## Test plan

- [x] `fdv2_rapidStateChangesCoalesceIntoOneRebuild` passes across repeated `--rerun-tasks` runs (6/6)
- [x] Full `ConnectivityManagerTest` class passes across repeated runs (3/3)
- [x] Full `:launchdarkly-android-client-sdk:testDebugUnitTest` suite passes (`BUILD SUCCESSFUL`)
- [x] No new lint errors; the new `MockPlatformState` helper is additive (other call sites unchanged)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and shared test-helper changes only; production SDK behavior is unchanged.
> 
> **Overview**
> Stabilizes **`fdv2_rapidStateChangesCoalesceIntoOneRebuild`** by fixing two test-only races that caused intermittent CI timeouts waiting for a data source stop.
> 
> In **`ConnectivityManagerTest`**, after `resetAll()` the phase that expects repeated **`EventProcessor`** updates now calls **`checkOrder(eventProcessor, false)`** so EasyMock strict ordering no longer rejects interleaved **`setOffline` / `setInBackground`** pairs when multiple connectivity updates run in parallel.
> 
> In **`MockPlatformState`**, adds **`setAndNotifyConnectivityChangeListenersInSequence(boolean...)`** to fire a burst of connectivity notifications **in order on one thread**. The debounce test switches from three separate **`setAndNotifyConnectivityChangeListeners`** calls to this helper so the sequence ends on **`false`** deterministically instead of sometimes finishing on **`true`** and suppressing the offline rebuild.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e9e9ad8d00c34a4dce927f92f5f6cfbd7751ac1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->