### PR TITLE
chore: enable FDv2 contract tests via sdk-test-harness v3.1.0-alpha.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,19 +18,11 @@ run-contract-tests:
 	@echo "Running SDK contract test v2..."
 	@curl $${GITHUB_TOKEN:+ -H "Authorization: Token $${GITHUB_TOKEN}"} \
       -s https://raw.githubusercontent.com/launchdarkly/sdk-test-harness/v2/downloader/run.sh \
-      | VERSION=v2 PARAMS="-url http://localhost:8001 -host 10.0.2.2 -debug -stop-service-at-end -skip-from $(SUPPRESSION_FILE) $(TEST_HARNESS_PARAMS_V2)" sh
-
-# Uncomment this, update v3 version, and replace existing run-contract-tests once sdk-test-harness releases a version that includes FDv2 client contract tests.
-#
-# run-contract-tests:
-# 	@echo "Running SDK contract test v2..."
-# 	@curl $${GITHUB_TOKEN:+ -H "Authorization: Token $${GITHUB_TOKEN}"} \
-#       -s https://raw.githubusercontent.com/launchdarkly/sdk-test-harness/v2/downloader/run.sh \
-#       | VERSION=v2 PARAMS="-url http://localhost:8001 -host 10.0.2.2 -debug -skip-from $(SUPPRESSION_FILE) $(TEST_HARNESS_PARAMS_V2)" sh
-# 	@echo "Running SDK contract test v3..."
-# 	@curl $${GITHUB_TOKEN:+ -H "Authorization: Token $${GITHUB_TOKEN}"} \
-#       -s https://raw.githubusercontent.com/launchdarkly/sdk-test-harness/v3.0.0-alpha.4/downloader/run.sh \
-#       | VERSION=v3.0.0-alpha.4 PARAMS="-url http://localhost:8001 -host 10.0.2.2 -debug -stop-service-at-end -skip-from $(SUPPRESSION_FILE_FDV2) $(TEST_HARNESS_PARAMS_V3)" sh
+      | VERSION=v2 PARAMS="-url http://localhost:8001 -host 10.0.2.2 -debug -skip-from $(SUPPRESSION_FILE) $(TEST_HARNESS_PARAMS_V2)" sh
+	@echo "Running SDK contract test v3..."
+	@curl $${GITHUB_TOKEN:+ -H "Authorization: Token $${GITHUB_TOKEN}"} \
+      -s https://raw.githubusercontent.com/launchdarkly/sdk-test-harness/v3.1.0-alpha.6/downloader/run.sh \
+      | VERSION=v3.1.0-alpha.6 PARAMS="-url http://localhost:8001 -host 10.0.2.2 -debug -stop-service-at-end -skip-from $(SUPPRESSION_FILE_FDV2) $(TEST_HARNESS_PARAMS_V3)" sh
 
 contract-tests: build-contract-tests start-emulator start-contract-test-service run-contract-tests
 


### PR DESCRIPTION
## Summary
- Uncomments the v3 contract-test invocation in the Makefile and pins it to sdk-test-harness `v3.1.0-alpha.6` — the first published alpha that includes [sdk-test-harness PR #325](https://github.com/launchdarkly/sdk-test-harness/pull/325) ("updates so FDv2 tests can run against client side sdks").
- Moves the `-stop-service-at-end` flag from the v2 invocation to the v3 invocation (v3 is now the final harness run).
- Deletes the obsolete "Uncomment this..." instruction block.

Targets the `sdk-2429-android-fdv2-eap` umbrella branch.

Tracking: [SDK-2442](https://launchdarkly.atlassian.net/browse/SDK-2442).

## Test plan
- [x] `make build-contract-tests` succeeds.
- [x] `make start-contract-test-service` installs and starts the APK on the emulator.
- [x] `make run-contract-tests` runs both harnesses cleanly:
  - v2 (FDv1): 798 total, 14 skipped, 784 ran — all passed.
  - v3 (FDv2, `v3.1.0-alpha.6`): 784 total, 21 skipped, 763 ran — all passed.
- [x] Test service stops cleanly after v3 completes.
- [ ] CI passes on this branch.

[SDK-2442]: https://launchdarkly.atlassian.net/browse/SDK-2442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Makefile-only CI/contract-test wiring with no production SDK or runtime behavior changes.
> 
> **Overview**
> **`make run-contract-tests` now runs both harnesses in sequence:** v2 (FDv1) unchanged except **`-stop-service-at-end` is removed**, then a new **v3** step pinned to **`sdk-test-harness/v3.1.0-alpha.6`** with **`SUPPRESSION_FILE_FDV2`**, **`TEST_HARNESS_PARAMS_V3`**, and **`-stop-service-at-end`** so the contract test service stops after the final run.
> 
> The old commented-out v3 block and “uncomment when ready” note are deleted; the Makefile comment still documents that only the last harness should pass **`-stop-service-at-end`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54f04b5441bdf4095c91abea831dec1b1f7620bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->