### PR TITLE
chore: advertise fdv2 capability in .sdk_metadata.json

### DIFF
--- a/.sdk_metadata.json
+++ b/.sdk_metadata.json
@@ -15,6 +15,7 @@
         "bigSegments": { "introduced": "1.0" },
         "contexts": { "introduced": "4.0" },
         "experimentation": { "introduced": "2.9" },
+        "fdv2": { "introduced": "5.13" },
         "flagChanges": { "introduced": "1.0" },
         "hooks": { "introduced": "5.8" },
         "inlineContextCustomEvents": { "introduced": "5.7" },


### PR DESCRIPTION
## Summary
- Adds `"fdv2": { "introduced": "5.13" }` to `.sdk_metadata.json` so downstream sdk-meta tooling lists the Android Client SDK as FDv2-capable.
- Inserted alphabetically between `experimentation` and `flagChanges`.

Mirrors the cross-SDK convention used by Python (#375 / metadata in 9.13), .NET (#221 / metadata in 8.11), Java (#120 / metadata in 7.11), Go (#342), Node (#1066).

Tracking: [SDK-2443](https://launchdarkly.atlassian.net/browse/SDK-2443).

## Test plan
- [x] JSON file parses (validated by the diff being a clean one-line add).
- [ ] CI passes on this branch.

## Note on the version pin
The `introduced` version assumes the EAP ships as `5.13`. If the umbrella branch advances past that minor before EAP cut, update this value to match the actual release version before merging `sdk-2429-android-fdv2-eap`.

[SDK-2443]: https://launchdarkly.atlassian.net/browse/SDK-2443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only JSON change with no effect on SDK runtime behavior.
> 
> **Overview**
> Registers **FDv2** as a supported Android Client SDK feature in `.sdk_metadata.json`, with `"introduced": "5.13"`, so sdk-meta and related tooling can treat this SDK as FDv2-capable (aligned with other LaunchDarkly client SDKs).
> 
> The new entry is placed alphabetically in the `features` map between `experimentation` and `flagChanges`. No runtime or SDK code changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1dd7d1b7a07bcc76ed54da840e80af75a5b8439. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->