### PR TITLE
fix: remove deprecation marker from LDConfig.Builder.plugins

### DIFF
--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDConfig.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDConfig.java
@@ -515,9 +515,6 @@ public class LDConfig {
         }
 
         /**
-         * This is an experimental API and may be removed/changed in the future without notice. It is
-         * marked as deprecated as Java does not have built in support for an experimental annotation.
-         * 
          * Sets the SDK's plugins configuration, using a builder. This is normally a obtained from
          * <p>
          * {@link Components#plugins()} ()}, which has methods for setting individual plugin
@@ -527,7 +524,6 @@ public class LDConfig {
          * @return the main configuration builder
          * @see Components#plugins()
          */
-        @Deprecated()
         public Builder plugins(PluginsConfigurationBuilder pluginsConfiguration) {
             this.pluginsConfigurationBuilder = pluginsConfiguration;
             return this;


### PR DESCRIPTION
## Summary

- `LDConfig.Builder.plugins(PluginsConfigurationBuilder)` was annotated `@Deprecated()` solely to signal that the plugins feature is experimental (Java has no built-in experimental annotation). There is no replacement method.
- This misleading marker causes a deprecation warning for every consumer that registers plugins (e.g. Observability / Session Replay) via the documented `Components.plugins().setPlugins(...)` pattern.
- This removes the `@Deprecated` annotation and the related "experimental API" javadoc paragraph, leaving the standard description consistent with the sibling `hooks(...)` builder method.

## Notes

- Verified no other plugins-related types (`Components.plugins()`, `PluginsConfigurationBuilder`, `PluginsConfiguration`) carry a deprecation/experimental marker, so this was the only spot.
- Versioning/changelog handled by the release system.

## Test plan

- [ ] CI build passes

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and annotation-only change with no logic or API signature changes.
> 
> **Overview**
> Removes the misleading **`@Deprecated`** annotation and the javadoc note that **`LDConfig.Builder.plugins(...)`** was only “experimental” on **`LDConfig.Builder.plugins(PluginsConfigurationBuilder)`**.
> 
> That API is the documented way to register plugins (e.g. via **`Components.plugins().setPlugins(...)`**); there is no replacement, so the deprecation marker only produced compiler warnings. Javadoc is now aligned with the sibling **`hooks(...)`** builder method. **No runtime or configuration behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c681c25d5dd8216a158166acea6a34685771dd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->